### PR TITLE
Add route to send data to Solr.

### DIFF
--- a/api/src/routes/messenger.ts
+++ b/api/src/routes/messenger.ts
@@ -1,3 +1,4 @@
+import Solr from '../services/Solr';
 import SolrIndexer from '../services/SolrIndexer';
 
 var express = require('express');
@@ -8,6 +9,16 @@ router.get("/solrindex/:pid", async function(req, res, next) {
     var fedoraFields = await indexer.getFields(req.params.pid);
 
     res.send(JSON.stringify(fedoraFields, null, "\t"));
+});
+
+router.post("/solrindex/:pid", async function(req, res, next) {
+    var indexer = new SolrIndexer();
+    var fedoraFields = await indexer.getFields(req.params.pid);
+    var solr = new Solr();
+    // TODO: make core name configurable
+    var result = await solr.indexRecord("biblio", fedoraFields);
+    res.status(result.statusCode)
+        .send(result.statusCode === 200 ? 'ok' : result.body.error.msg ?? "error");
 });
 
 module.exports = router;

--- a/api/src/services/Solr.ts
+++ b/api/src/services/Solr.ts
@@ -1,0 +1,39 @@
+const http = require("needle");
+
+class Solr {
+    baseUrl: string;
+
+    constructor() {
+        // TODO: make configurable
+        this.baseUrl = "http://localhost:8983/solr";
+    }
+
+    /**
+     * Make request to Solr
+     */
+    protected _request(
+        method: string = "get",
+        _path: string = "/",
+        data: any = null,
+        options: object = {}
+    ): Promise<any> {
+        let path = _path[0] == "/" ? _path.slice(1) : _path;
+        let url = this.baseUrl + "/" + path;
+        console.log(method, url, data);
+        return http(method, url, data, options);
+    }
+
+    async indexRecord(core, _data) {
+        let data = { add: { doc: _data } };
+        return this._request(
+            "post",
+            core + "/update?commit=true",
+            JSON.stringify(data),
+            {
+                headers: { 'Content-Type' : 'application/json'}
+            }
+        );
+    }
+}
+
+export default Solr;


### PR DESCRIPTION
This PR adds the ability to index to Solr for real. I tested it with my local VuFind instance, and have confirmed that it works. I set this up so that if you GET /solrindex/[pid], you see the results of the indexing, but if you POST there, it actually does the indexing. We can revisit/discuss/revise the HTTP interface as needed... but this seems like a good enough proof of concept.