### PR TITLE
Add eslint and JSDoc checks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,13 @@
+module.exports = {
+  root: true,
+  parser: "@typescript-eslint/parser",
+  plugins: [
+    "@typescript-eslint",
+    "jsdoc"
+  ],
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:jsdoc/recommended"
+  ]
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,11 +4,11 @@ module.exports = {
     node: true
   },
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: "module",
   },
   extends: [
     "eslint:recommended",
-    // "plugin:prettier/recommended"
+    "plugin:prettier/recommended"
   ]
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,14 +1,11 @@
 module.exports = {
-  root: true,
-  env: {
-    node: true
-  },
-  parserOptions: {
-    ecmaVersion: 2020,
-    sourceType: "module",
-  },
-  extends: [
-    "eslint:recommended",
-    "plugin:prettier/recommended"
-  ]
+    root: true,
+    env: {
+        es2020: true,
+        node: true,
+    },
+    parserOptions: {
+        sourceType: "module",
+    },
+    extends: ["eslint:recommended", "plugin:prettier/recommended"],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,13 +1,14 @@
 module.exports = {
   root: true,
-  parser: "@typescript-eslint/parser",
-  plugins: [
-    "@typescript-eslint",
-    "jsdoc"
-  ],
+  env: {
+    node: true
+  },
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: "module",
+  },
   extends: [
     "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:jsdoc/recommended"
+    // "plugin:prettier/recommended"
   ]
 };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+    printWidth: 120,
+    tabWidth: 4
+};

--- a/api/.eslintrc.js
+++ b/api/.eslintrc.js
@@ -1,11 +1,6 @@
 module.exports = {
-  root: false,
-  parser: "@typescript-eslint/parser",
-  plugins: [
-    "@typescript-eslint",
-    "jsdoc",
-  ],
-  extends: [
-    "plugin:@typescript-eslint/recommended"
-  ]
+    root: false,
+    parser: "@typescript-eslint/parser",
+    plugins: ["@typescript-eslint", "jsdoc"],
+    extends: ["plugin:@typescript-eslint/recommended"],
 };

--- a/api/.eslintrc.js
+++ b/api/.eslintrc.js
@@ -1,0 +1,11 @@
+module.exports = {
+  root: false,
+  parser: "@typescript-eslint/parser",
+  plugins: [
+    "@typescript-eslint",
+    "jsdoc",
+  ],
+  extends: [
+    "plugin:@typescript-eslint/recommended",
+  ]
+};

--- a/api/.eslintrc.js
+++ b/api/.eslintrc.js
@@ -6,6 +6,6 @@ module.exports = {
     "jsdoc",
   ],
   extends: [
-    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended"
   ]
 };

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
     "react"
   ],
   extends: [
-    "plugin:react/recommended",
+    "plugin:react/recommended"
   ],
   settings: {
     react: {

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -1,0 +1,18 @@
+module.exports = {
+  root: false,
+  env: {
+    browser: true
+  },
+  plugins: [
+    "react"
+  ],
+  extends: [
+    "plugin:react/recommended",
+  ],
+  settings: {
+    react: {
+      pragma: "React",
+      version: "detect"
+    }
+  }
+};

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -1,18 +1,14 @@
 module.exports = {
-  root: false,
-  env: {
-    browser: true
-  },
-  plugins: [
-    "react"
-  ],
-  extends: [
-    "plugin:react/recommended"
-  ],
-  settings: {
-    react: {
-      pragma: "React",
-      version: "detect"
-    }
-  }
+    root: false,
+    env: {
+        browser: true,
+    },
+    plugins: ["react"],
+    extends: ["plugin:react/recommended"],
+    settings: {
+        react: {
+            pragma: "React",
+            version: "detect",
+        },
+    },
 };

--- a/package.json
+++ b/package.json
@@ -26,10 +26,16 @@
 
     "build": "concurrently npm:api:build npm:client:build",
     "dev": "concurrently -c 'cyan,green,gray' npm:client npm:api:dev npm:queue:dev",
+    "lint": "eslint api/app.js api/src client/src",
     "start": "concurrently -c 'cyan,green,gray' npm:client npm:api npm:queue"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^4.22.0",
+    "@typescript-eslint/parser": "^4.22.0",
     "concurrently": "^6.0.2",
-    "nodemon": "^2.0.7"
+    "eslint": "^7.24.0",
+    "eslint-plugin-jsdoc": "^32.3.1",
+    "nodemon": "^2.0.7",
+    "typescript": "^4.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,15 +26,16 @@
 
     "build": "concurrently npm:api:build npm:client:build",
     "dev": "concurrently -c 'cyan,green,gray' npm:client npm:api:dev npm:queue:dev",
-    "lint": "eslint api/app.js api/src client/src",
+    "lint": "eslint api/*.js api/src/ client/src/ --ext .ts,.js,.jsx",
     "start": "concurrently -c 'cyan,green,gray' npm:client npm:api npm:queue"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
     "concurrently": "^6.0.2",
-    "eslint": "^7.24.0",
+    "eslint": "^7.25.0",
     "eslint-plugin-jsdoc": "^32.3.1",
+    "eslint-plugin-react": "^7.23.2",
     "nodemon": "^2.0.7",
     "typescript": "^4.2.4"
   }

--- a/package.json
+++ b/package.json
@@ -34,9 +34,12 @@
     "@typescript-eslint/parser": "^4.22.0",
     "concurrently": "^6.0.2",
     "eslint": "^7.25.0",
+    "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-jsdoc": "^32.3.1",
+    "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-react": "^7.23.2",
     "nodemon": "^2.0.7",
+    "prettier": "^2.2.1",
     "typescript": "^4.2.4"
   }
 }


### PR DESCRIPTION
`npm run lint`

- [ ] Run --fix before merging? (133 errors and 10 warnings potentially fixable with the `--fix` option.)
- [ ] Do we want an autoformatter? ie. [Prettier](https://github.com/prettier/eslint-plugin-prettier)

Some rules oddities that we may want to adjust
- `prefer-const` wants to enforce `for (const item of array)`
- *that's it to my eye*-