### PR TITLE
Fix bug in derivative path determination.

### DIFF
--- a/api/src/models/ImageFile.ts
+++ b/api/src/models/ImageFile.ts
@@ -61,7 +61,8 @@ class ImageFile {
     derivativePath(size, extension = "jpg") {
         var path = require('path');
         var dir = path.dirname(this.filename);
-        var filename = this.basename(this.filename);
+        const ext = this.filename.substr(this.filename.lastIndexOf('.'));
+        var filename = path.basename(this.filename, ext);
         return dir + "/" + filename + "/" + size + "/" + filename + "." + extension.toLowerCase();
     }
 


### PR DESCRIPTION
I just discovered that the derivative path generation was still not correct -- it was using the full name of the TIFF, not the base name without extension, which was causing a conflict and breaking everything. This PR should fix it.