### PR TITLE
Improve .ini/config handling.

### DIFF
--- a/api/src/jobs/Ingest.ts
+++ b/api/src/jobs/Ingest.ts
@@ -234,7 +234,7 @@ class IngestProcessor {
     }
 
     moveDirectory() {
-        const basePath = Config.getInstance().processedAreaPath();
+        const basePath = Config.getInstance().processedAreaPath;
         const currentTime = new Date();
         const now = currentTime.toISOString().substr(0, 10);
         let target = basePath + "/" + now + "/" + this.category.name + "/" + this.job.name;

--- a/api/src/models/AudioFile.ts
+++ b/api/src/models/AudioFile.ts
@@ -2,7 +2,7 @@
 import fs = require("fs");
 import path = require("path");
 
-import Config from "./Config";
+// TODO: reintroduce config when needed: import Config from "./Config";
 
 class AudioFile {
     filename: string;
@@ -12,11 +12,6 @@ class AudioFile {
     constructor(filename: string, dir: string) {
         this.filename = filename;
         this.dir = dir;
-    }
-
-    config(): string {
-        const config = Config.getInstance();
-        return config.restBaseUrl();
     }
 
     derivative(extension: string): void {

--- a/api/src/models/Config.ts
+++ b/api/src/models/Config.ts
@@ -1,4 +1,6 @@
 import PrivateConfig from "./PrivateConfig";
+import fs = require("fs");
+import ini = require("ini");
 
 class Config {
     private static instance: PrivateConfig;
@@ -9,7 +11,9 @@ class Config {
 
     public static getInstance(): PrivateConfig {
         if (!Config.instance) {
-            Config.instance = new PrivateConfig();
+            const config = ini.parse(fs.readFileSync(__dirname.replace(/\\/g, "/") + "/../../vudl.ini", "utf-8"));
+            // ini returns any, but we can cast it to what we need:
+            Config.instance = new PrivateConfig(config as Record<string, string>);
         }
         return Config.instance;
     }

--- a/api/src/models/ImageFile.ts
+++ b/api/src/models/ImageFile.ts
@@ -72,7 +72,7 @@ class ImageFile {
         if (!fs.existsSync(txt)) {
             // const path = path.basename(txt);
             const config = Config.getInstance();
-            const ts_cmd = config.tesseractPath() + " " + deriv + " " + txt.slice(0, -4) + " " + this.ocrProperties();
+            const ts_cmd = config.tesseractPath + " " + deriv + " " + txt.slice(0, -4) + " " + this.ocrProperties();
             exec(ts_cmd, (error, stdout, stderr) => {
                 if (error) {
                     throw `error: ${error.message + " " + stderr}`;
@@ -93,7 +93,7 @@ class ImageFile {
         const deriv = await this.derivative("LARGE");
         if (!fs.existsSync(png)) {
             const config = Config.getInstance();
-            const tc_cmd = config.textcleanerPath() + " " + config.textcleanerSwitches() + " " + deriv + " " + png;
+            const tc_cmd = config.textcleanerPath + " " + config.textcleanerSwitches + " " + deriv + " " + png;
             exec(tc_cmd, (error, stdout, stderr) => {
                 if (error) {
                     throw `error: ${error.message + " " + stderr}`;

--- a/api/src/models/ImageFile.ts
+++ b/api/src/models/ImageFile.ts
@@ -6,7 +6,6 @@ import { exec } from "child_process";
 // import { stringify } from "node:querystring";
 
 import Config from "./Config";
-import PrivateConfig from "./PrivateConfig";
 
 import fs = require("fs");
 
@@ -20,11 +19,6 @@ class ImageFile {
 
     constructor(filename: string) {
         this.filename = filename;
-    }
-
-    config(): PrivateConfig {
-        const config = Config.getInstance();
-        return config;
     }
 
     constraintForSize(size: string): number {
@@ -77,8 +71,8 @@ class ImageFile {
         const deriv = await this.ocrDerivative();
         if (!fs.existsSync(txt)) {
             // const path = path.basename(txt);
-            const ts_cmd =
-                this.config().tesseractPath() + " " + deriv + " " + txt.slice(0, -4) + " " + this.ocrProperties();
+            const config = Config.getInstance();
+            const ts_cmd = config.tesseractPath() + " " + deriv + " " + txt.slice(0, -4) + " " + this.ocrProperties();
             exec(ts_cmd, (error, stdout, stderr) => {
                 if (error) {
                     throw `error: ${error.message + " " + stderr}`;
@@ -98,8 +92,8 @@ class ImageFile {
         const png = this.derivativePath("ocr/pngs", "png");
         const deriv = await this.derivative("LARGE");
         if (!fs.existsSync(png)) {
-            const tc_cmd =
-                this.config().textcleanerPath() + " " + this.config().textcleanerSwitches() + " " + deriv + " " + png;
+            const config = Config.getInstance();
+            const tc_cmd = config.textcleanerPath() + " " + config.textcleanerSwitches() + " " + deriv + " " + png;
             exec(tc_cmd, (error, stdout, stderr) => {
                 if (error) {
                     throw `error: ${error.message + " " + stderr}`;

--- a/api/src/models/Job.ts
+++ b/api/src/models/Job.ts
@@ -1,7 +1,7 @@
 import { openSync, closeSync, existsSync as fileExists } from "fs";
 import path = require("path");
 
-import Config from "./Config";
+// TODO: reintroduce config when needed: import Config from "./Config";
 import JobMetadata from "./JobMetadata";
 import ImageFile from "./ImageFile";
 import { Queue } from "bullmq";
@@ -39,18 +39,6 @@ class Job {
             const q = new Queue("vudl");
             q.add("derivatives", { dir: this.dir });
         }
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    config(): any {
-        // TODO: This is just a test, right?
-        // any returned from "ini" library
-        const config = Config.getInstance().ini();
-        console.log(config.message); // Prints out: 'I am an instance'
-        config.message = "Foo Bar"; // Overwrite message property
-        const instance = config.getInstance().ini();
-        console.log(instance.message); // Prints out: 'Foo Bar'
-        return instance;
     }
 
     generatePdf(): void {

--- a/api/src/models/PrivateConfig.ts
+++ b/api/src/models/PrivateConfig.ts
@@ -1,79 +1,72 @@
-import fs = require("fs");
-import ini = require("ini"); // returns <any>
-
 class PrivateConfig {
-    constructor() {
-        //this.message = 'I am an instance';
-    }
+    protected ini;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ini(): any {
-        const config = ini.parse(fs.readFileSync(__dirname.replace(/\\/g, "/") + "/../../vudl.ini", "utf-8"));
-        return config;
+    constructor(ini: Record<string, string>) {
+        this.ini = ini;
     }
 
     fedoraHostUrl(): string {
-        return this.ini()["fedora_host"];
+        return this.ini["fedora_host"];
     }
 
     fedoraApiUrl(): string {
-        return this.ini()["fedora_api"];
+        return this.ini["fedora_api"];
     }
 
     fedoraUsername(): string {
-        return this.ini()["fedora_username"];
+        return this.ini["fedora_username"];
     }
 
     fedoraPassword(): string {
-        return this.ini()["fedora_password"];
+        return this.ini["fedora_password"];
     }
 
     fedoraPidNameSpace(): string {
-        return this.ini()["fedora_pid_namespace"];
+        return this.ini["fedora_pid_namespace"];
     }
 
     solrQueryUrl(): string {
-        return this.ini()["solr_query_url"];
+        return this.ini["solr_query_url"];
     }
 
     tesseractPath(): string {
-        return this.ini()["tesseract_path"];
+        return this.ini["tesseract_path"];
     }
 
     vufindUrl(): string {
-        return this.ini()["vufind_url"];
+        return this.ini["vufind_url"];
     }
 
     pdfDirectory(): string {
-        return this.ini()["pdf_directory"];
+        return this.ini["pdf_directory"];
     }
 
     textcleanerPath(): string {
-        return this.ini()["textcleaner_path"];
+        return this.ini["textcleaner_path"];
     }
 
     textcleanerSwitches(): string {
-        return this.ini()["textcleaner_switches"];
+        return this.ini["textcleaner_switches"];
     }
 
     holdingArea(): string {
-        return this.ini()["holding_area_path"];
+        return this.ini["holding_area_path"];
     }
 
     processedAreaPath(): string {
-        return this.ini()["processed_area_path"];
+        return this.ini["processed_area_path"];
     }
 
     restBaseUrl(): string {
-        return this.ini()["base_url"];
+        return this.ini["base_url"];
     }
 
     requireLogin(): string {
-        return this.ini()["require_login"];
+        return this.ini["require_login"];
     }
 
     userWhitelist(): string {
-        return this.ini()["user_whitelist"];
+        return this.ini["user_whitelist"];
     }
 }
 

--- a/api/src/models/PrivateConfig.ts
+++ b/api/src/models/PrivateConfig.ts
@@ -5,67 +5,71 @@ class PrivateConfig {
         this.ini = ini;
     }
 
-    fedoraHostUrl(): string {
+    get fedoraHostUrl(): string {
+        // TODO: not used -- do we need this?
         return this.ini["fedora_host"];
     }
 
-    fedoraApiUrl(): string {
+    get fedoraApiUrl(): string {
+        // TODO: not used -- do we need this? How does it differ from restBaseUrl() below?
         return this.ini["fedora_api"];
     }
 
-    fedoraUsername(): string {
+    get fedoraUsername(): string {
         return this.ini["fedora_username"];
     }
 
-    fedoraPassword(): string {
+    get fedoraPassword(): string {
         return this.ini["fedora_password"];
     }
 
-    fedoraPidNameSpace(): string {
+    get fedoraPidNameSpace(): string {
         return this.ini["fedora_pid_namespace"];
     }
 
-    solrQueryUrl(): string {
+    get solrQueryUrl(): string {
         return this.ini["solr_query_url"];
     }
 
-    tesseractPath(): string {
+    get tesseractPath(): string {
         return this.ini["tesseract_path"];
     }
 
-    vufindUrl(): string {
+    get vufindUrl(): string {
         return this.ini["vufind_url"];
     }
 
-    pdfDirectory(): string {
+    get pdfDirectory(): string {
         return this.ini["pdf_directory"];
     }
 
-    textcleanerPath(): string {
+    get textcleanerPath(): string {
         return this.ini["textcleaner_path"];
     }
 
-    textcleanerSwitches(): string {
+    get textcleanerSwitches(): string {
         return this.ini["textcleaner_switches"];
     }
 
-    holdingArea(): string {
+    get holdingArea(): string {
         return this.ini["holding_area_path"];
     }
 
-    processedAreaPath(): string {
+    get processedAreaPath(): string {
         return this.ini["processed_area_path"];
     }
 
-    restBaseUrl(): string {
+    get restBaseUrl(): string {
         return this.ini["base_url"];
     }
 
-    requireLogin(): string {
+    get requireLogin(): string {
+        // TODO: do we need this, or will authentication be handled differently in future?
         return this.ini["require_login"];
     }
 
-    userWhitelist(): string {
+    get userWhitelist(): string {
+        // TODO: do we need this, or will authentication be handled differently in future?
         return this.ini["user_whitelist"];
     }
 }

--- a/api/src/routes/api.ts
+++ b/api/src/routes/api.ts
@@ -12,7 +12,7 @@ function getJobFromRequest(req): Job {
 }
 
 function holdingArea(): string {
-    const holdingArea = Config.getInstance().holdingArea();
+    const holdingArea = Config.getInstance().holdingArea;
     return holdingArea.endsWith("/") ? holdingArea : holdingArea + "/";
 }
 

--- a/api/src/services/Fedora.ts
+++ b/api/src/services/Fedora.ts
@@ -25,7 +25,7 @@ export class Fedora {
 
     constructor() {
         const config = Config.getInstance();
-        this.baseUrl = config.restBaseUrl();
+        this.baseUrl = config.restBaseUrl;
     }
 
     /**


### PR DESCRIPTION
- Use dependency injection to pass .ini contents into PrivateConfig (so we load the file only once, instead of every time a setting is requested).
- Eliminate config methods in model classes (unneeded, since we can use Config.getInstance() directly).
- Use typecasting, so we don't have to suppress eslint warnings about use of any.