### PR TITLE
Remove unused basename method.

### DIFF
--- a/api/src/models/ImageFile.ts
+++ b/api/src/models/ImageFile.ts
@@ -146,10 +146,6 @@ class ImageFile {
             }
         }
     }
-
-    basename(path: string): string {
-        return path.replace(/\/$/, "").split("/").reverse()[0];
-    }
 }
 
 export default ImageFile;


### PR DESCRIPTION
Just happened to notice that this unused method was still hanging around; pretty sure it's safe to delete it! (We're using the built-in path.basename now instead of inventing our own version).