### PR TITLE
Complete, fix and test OCR functionality.

### DIFF
--- a/api/src/models/ImageFile.ts
+++ b/api/src/models/ImageFile.ts
@@ -105,16 +105,10 @@ class ImageFile {
         if (!fs.existsSync(dir)) {
             fs.mkdirSync(dir, { recursive: true });
         }
-        const content =
-            "tessedit_char_whitelist ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789.,;:!'\"()&$%-+=[]?<>" +
-            "\xE2\x80\x9C\xE2\x80\x9D\xE2\x80\x98\xE2\x80\x99";
+        const allowedChars = Config.getInstance().tesseractAllowedChars;
+        const content = allowedChars ? "tessedit_char_whitelist " + allowedChars : "";
         if (!fs.existsSync(file)) {
-            fs.writeFile(file, content, (err) => {
-                if (err) {
-                    throw err;
-                }
-                // file written successfully
-            });
+            fs.writeFileSync(file, content);
         }
         return file;
     }

--- a/api/src/models/ImageFile.ts
+++ b/api/src/models/ImageFile.ts
@@ -1,9 +1,7 @@
 import Jimp = require("jimp");
 import path = require("path");
 
-import { exec } from "child_process";
-// import { constants } from "node:buffer";
-// import { stringify } from "node:querystring";
+import { execSync } from "child_process";
 
 import Config from "./Config";
 
@@ -66,55 +64,47 @@ class ImageFile {
     }
 
     async ocr(): Promise<string> {
-        //TODO: Test for completeness
         const txt = this.derivativePath("OCR-DIRTY", "txt");
-        const deriv = await this.ocrDerivative();
         if (!fs.existsSync(txt)) {
-            // const path = path.basename(txt);
+            const txtPath = path.dirname(txt);
+            if (!fs.existsSync(txtPath)) {
+                fs.mkdirSync(txtPath, { recursive: true });
+            }
+            const deriv = await this.ocrDerivative();
             const config = Config.getInstance();
             const ts_cmd = config.tesseractPath + " " + deriv + " " + txt.slice(0, -4) + " " + this.ocrProperties();
-            exec(ts_cmd, (error, stdout, stderr) => {
-                if (error) {
-                    throw `error: ${error.message + " " + stderr}`;
-                }
-                if (stderr) {
-                    console.log(`stderr: ${stderr}`);
-                }
-                if (!fs.existsSync(txt)) {
-                    throw "Problem running tesseract";
-                }
-                console.log(`stdout: ${stdout}`);
-            });
-            return "TODO -- write text file";
+            execSync(ts_cmd);
+            if (!fs.existsSync(txt)) {
+                throw "Problem running tesseract";
+            }
         }
-        return fs.readFileSync(txt, "utf-8");
+        return txt;
     }
 
     async ocrDerivative(): Promise<string> {
         const png = this.derivativePath("ocr/pngs", "png");
-        const deriv = await this.derivative("LARGE");
         if (!fs.existsSync(png)) {
+            const pngPath = path.dirname(png);
+            if (!fs.existsSync(pngPath)) {
+                fs.mkdirSync(pngPath, { recursive: true });
+            }
             const config = Config.getInstance();
+            const deriv = await this.derivative("LARGE");
             const tc_cmd = config.textcleanerPath + " " + config.textcleanerSwitches + " " + deriv + " " + png;
-            exec(tc_cmd, (error, stdout, stderr) => {
-                if (error) {
-                    throw `error: ${error.message + " " + stderr}`;
-                }
-                if (stderr) {
-                    console.log(`stderr: ${stderr}`);
-                }
-                if (!fs.existsSync(png)) {
-                    throw "Problem running textcleaner";
-                }
-                console.log(`stdout: ${stdout}`);
-            });
+            execSync(tc_cmd);
+            if (!fs.existsSync(png)) {
+                throw "Problem running textcleaner";
+            }
         }
         return png;
     }
 
     ocrProperties(): string {
         const file = path.dirname(this.filename) + "/ocr/tesseract.config";
-        // const dir = path.dirname(file);
+        const dir = path.dirname(file);
+        if (!fs.existsSync(dir)) {
+            fs.mkdirSync(dir, { recursive: true });
+        }
         const content =
             "tessedit_char_whitelist ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789.,;:!'\"()&$%-+=[]?<>" +
             "\xE2\x80\x9C\xE2\x80\x9D\xE2\x80\x98\xE2\x80\x99";
@@ -123,7 +113,7 @@ class ImageFile {
                 if (err) {
                     throw err;
                 }
-                //file written successfully
+                // file written successfully
             });
         }
         return file;

--- a/api/src/models/ImageFile.ts
+++ b/api/src/models/ImageFile.ts
@@ -63,7 +63,7 @@ class ImageFile {
         return dir + "/" + filename + "/" + size + "/" + filename + "." + extension.toLowerCase();
     }
 
-    protected filterIllegalCharacters(txt): void {
+    protected filterIllegalCharacters(txt: string): void {
         const allowedChars = Config.getInstance().tesseractAllowedChars;
         // Only filter if we have a non-empty setting:
         if (allowedChars) {

--- a/api/src/models/ImageFile.ts
+++ b/api/src/models/ImageFile.ts
@@ -69,7 +69,7 @@ class ImageFile {
         if (allowedChars) {
             const content = fs.readFileSync(txt);
             const regexpStr = "[^" + allowedChars.replace(/[-[\]{}()*+?.,\\^$|]/g, "\\$&") + "\\s]";
-            const regexp = new RegExp(regexpStr, 'g');
+            const regexp = new RegExp(regexpStr, "g");
             const filteredTxt = content.toString().replace(regexp, "");
             fs.writeFileSync(txt, filteredTxt);
         }

--- a/api/src/models/PrivateConfig.ts
+++ b/api/src/models/PrivateConfig.ts
@@ -35,6 +35,10 @@ class PrivateConfig {
         return this.ini["tesseract_path"];
     }
 
+    get tesseractAllowedChars(): string {
+        return this.ini["tesseract_allowed_characters"];
+    }
+
     get vufindUrl(): string {
         return this.ini["vufind_url"];
     }

--- a/api/vudl.ini.dist
+++ b/api/vudl.ini.dist
@@ -11,7 +11,7 @@ solr_query_url = "http://myserver:8983/solr/core/query"
 tesseract_path = "/usr/local/bin/tesseract"
 
 # This setting lists characters that may be included in OCR output. Leave the
-# the setting commented out for unfiltered output.
+# setting commented out for unfiltered output.
 #tesseract_allowed_characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789.,;:!'\"()&$%-+=[]?<>“”‘’—"
 
 # Settings for ocrmypdf (omit setting to skip this step if you aren't using it)

--- a/api/vudl.ini.dist
+++ b/api/vudl.ini.dist
@@ -10,11 +10,9 @@ solr_query_url = "http://myserver:8983/solr/core/query"
 # Settings for Tesseract OCR
 tesseract_path = "/usr/local/bin/tesseract"
 
-# This setting lists characters that may be included in OCR output. To use this
-# setting with Tesseract 4+, you need to add "-oem 0" to the tesseract_path
-# setting above to put Tesseract into legacy mode. This is not recommended.
-# (In other words, this setting is recommended only for Tesseract 3).
-#tesseract_allowed_characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789.,;:!'\"()&$%-+=[]?<>“”‘’"
+# This setting lists characters that may be included in OCR output. Leave the
+# the setting commented out for unfiltered output.
+#tesseract_allowed_characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789.,;:!'\"()&$%-+=[]?<>“”‘’—"
 
 # Settings for ocrmypdf (omit setting to skip this step if you aren't using it)
 #ocrmypdf_path = /usr/local/bin/ocrmypdf

--- a/api/vudl.ini.dist
+++ b/api/vudl.ini.dist
@@ -10,6 +10,12 @@ solr_query_url = "http://myserver:8983/solr/core/query"
 # Settings for Tesseract OCR
 tesseract_path = "/usr/local/bin/tesseract"
 
+# This setting lists characters that may be included in OCR output. To use this
+# setting with Tesseract 4+, you need to add "-oem 0" to the tesseract_path
+# setting above to put Tesseract into legacy mode. This is not recommended.
+# (In other words, this setting is recommended only for Tesseract 3).
+#tesseract_allowed_characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789.,;:!'\"()&$%-+=[]?<>“”‘’"
+
 # Settings for ocrmypdf (omit setting to skip this step if you aren't using it)
 #ocrmypdf_path = /usr/local/bin/ocrmypdf
 


### PR DESCRIPTION
This PR fixes the textcleaner and Tesseract functionality.

This was a little bit more complicated than anticipated, because the code relied on a Tesseract 3 config setting that no longer works in Tesseract 4. In order to improve compatibility, I rewrote the character filtering as a post-processing step instead of a Tesseract configuration. This will likely result in poorer results from Tesseract 3 (since the filter choices are no longer informing the behavior of the OCR engine), but since most people are likely to use Tesseract 4 anyway, I think it's okay for our purposes.