### PR TITLE
Add PID generator.

### DIFF
--- a/api/src/models/FedoraObject.ts
+++ b/api/src/models/FedoraObject.ts
@@ -1,6 +1,8 @@
 import fs = require("fs");
 import winston = require("winston");
+import Config from "./Config";
 import Fedora from "../services/Fedora";
+import { getNextPid } from "../services/Database";
 
 export interface DatastreamParameters {
     checksumType?: string;
@@ -38,14 +40,12 @@ export class FedoraObject {
         this.logger = logger;
     }
 
-    static getNextPid(): string {
-        // TODO
-        return "FAKE";
+    static async getNextPid(): Promise<string> {
+        return getNextPid(Config.getInstance().pidNamespace);
     }
 
     get namespace(): string {
-        // TODO: make configurable, or eliminate if unneeded
-        return "vudl";
+        return Config.getInstance().pidNamespace;
     }
 
     addDatastream(id: string, params: DatastreamParameters, data: string): void {

--- a/api/src/models/PrivateConfig.ts
+++ b/api/src/models/PrivateConfig.ts
@@ -105,6 +105,14 @@ class PrivateConfig {
     get allowedOrigins(): string[] {
         return this.ini["allowed_origins"];
     }
+
+    get pidNamespace(): string {
+        return this.ini["fedora_pid_namespace"] ?? "vudl";
+    }
+
+    get initialPidValue(): number {
+        return parseInt(this.ini["fedora_initial_pid"] ?? "1");
+    }
 }
 
 export default PrivateConfig;

--- a/api/src/services/Database.ts
+++ b/api/src/services/Database.ts
@@ -1,5 +1,6 @@
 import fs = require("fs");
 import path = require("path");
+import Config from "../models/Config";
 import { Knex, knex } from "knex";
 import { nanoid } from "nanoid";
 
@@ -18,6 +19,10 @@ interface Token {
     created_at: number;
     user_id: number;
 }
+interface Pid {
+    namespace: string;
+    pid: number;
+}
 
 async function createDatabase(db): Promise<void> {
     console.log("Database:createTables");
@@ -34,6 +39,18 @@ async function createDatabase(db): Promise<void> {
         table.timestamp("created_at").notNullable();
         table.integer("user_id").unsigned().references("users.id");
     });
+    await db.schema.dropTableIfExists("pids");
+    await db.schema.createTable("pids", (table) => {
+        table.string("namespace").primary();
+        table.integer("pid");
+    });
+    const config = Config.getInstance();
+    const initialPid: Pid = {
+        namespace: config.fedoraPidNameSpace,
+        pid: config.initialPidValue,
+    };
+    await db("pids").insert(initialPid);
+
     const users = [
         { username: "geoff", password: "earth", hash: "CuhFfwkebs3RKr1Zo_Do_" },
         { username: "chris", password: "air", hash: "V1StGXR8_Z5jdHi6B-myT" },
@@ -90,6 +107,31 @@ export async function confirmToken(token: string): Promise<boolean> {
         return false;
     }
     return true;
+}
+
+export async function getNextPid(namespace: string): Promise<string> {
+    const db = await getDatabase();
+    let pid = "";
+    // We don't want to create a duplicate PID or get out of sync, so we need to
+    // do this as a transcation!
+    await db.transaction(async function (trx) {
+        // Get the latest PID, and fail if we can't find it:
+        const current = await trx<Pid>("pids").where("namespace", namespace);
+        if (current.length < 1) {
+            throw "Cannot find PID for namespace: " + namespace;
+        }
+        // Increment the PID and update the database:
+        const numericPortion = current[0].pid + 1;
+        await trx("pids").where("namespace", namespace).update("pid", numericPortion);
+        // Commit the transaction:
+        await trx.commit();
+        // Only update the variable AFTER everything has been successful:
+        pid = namespace + ":" + numericPortion;
+    });
+    if (pid.length === 0) {
+        throw "Unexpected pid generation error.";
+    }
+    return pid;
 }
 
 export async function makeToken(user: User): Promise<string> {

--- a/api/vudl.ini.dist
+++ b/api/vudl.ini.dist
@@ -9,6 +9,9 @@ fedora_username = "fedoraAdmin"
 fedora_password = "fedoraAdmin"
 fedora_pid_namespace = "vudl"
 
+# The first number for the PID generator to use:
+fedora_initial_pid = "1"
+
 solr_query_url = "http://myserver:8983/solr/core/query"
 
 # Settings for Tesseract OCR


### PR DESCRIPTION
We need to generate PIDs when we create new objects. I'm pretty sure that Fedora no longer does this for us, so I built a simple database-driven PID generator for us. This is one of the first steps required for making the ingest process work "for real." If it turns out there is a native F6 PID service in the future, we can always substitute it for this... but this should get us going for now.

A couple of notes:
- This required me to make more parts of the ingest job async, and while I was doing that, I noticed and fixed some missing types.
- In order to try this out, you'll need to delete your data directory so that the database gets rebuilt with the new pid generator table.