### PR TITLE
Move holding directory to processed area.

### DIFF
--- a/api/src/jobs/Ingest.ts
+++ b/api/src/jobs/Ingest.ts
@@ -252,11 +252,12 @@ class IngestProcessor {
             target = target + "." + i;
         }
         this.logger.info("Moving " + this.job.dir + " to " + target);
-        // TODO: move the directory and clean up (original Ruby below):
-        //FileUtils.mkdir_p target unless File.exist?(target)
-        //FileUtils.mv Dir.glob("#{@job.dir}/*"), target
-        //FileUtils.rmdir @job.dir
-        //FileUtils.rm "#{target}/ingest.lock"
+        const targetParent = path.dirname(target);
+        if (!fs.existsSync(targetParent)) {
+            fs.mkdirSync(targetParent, {recursive: true});
+        }
+        fs.renameSync(this.job.dir, target);
+        fs.unlinkSync(target + "/ingest.lock");
     }
 
     async doIngest(): Promise<void> {

--- a/api/src/jobs/Ingest.ts
+++ b/api/src/jobs/Ingest.ts
@@ -254,7 +254,7 @@ class IngestProcessor {
         this.logger.info("Moving " + this.job.dir + " to " + target);
         const targetParent = path.dirname(target);
         if (!fs.existsSync(targetParent)) {
-            fs.mkdirSync(targetParent, {recursive: true});
+            fs.mkdirSync(targetParent, { recursive: true });
         }
         fs.renameSync(this.job.dir, target);
         fs.unlinkSync(target + "/ingest.lock");


### PR DESCRIPTION
This completes the final TODO of the VuDLPrep port. Note that this fails with a permission error when I try to run it on files shared from my host environment through VirtualBox, but it succeeds when my source and destination files reside on the VM's own file system. I don't think that is a major cause for concern, but something to be aware of if you test using that configuration.