### PR TITLE
Make indexing process more configurable

### DIFF
--- a/api/src/models/PrivateConfig.ts
+++ b/api/src/models/PrivateConfig.ts
@@ -101,6 +101,30 @@ class PrivateConfig {
     get initialPidValue(): number {
         return parseInt(this.ini["fedora_initial_pid"] ?? "1");
     }
+
+    get institution(): string {
+        return this.ini["institution"] ?? "My University";
+    }
+
+    get collection(): string {
+        return this.ini["collection"] ?? "Digital Library";
+    }
+
+    get topLevelPids(): Array<string> {
+        return this.ini["top_level_pids"] ?? [];
+    }
+
+    get articlesToStrip(): Array<string> {
+        return this.ini["articles_to_strip"] ?? [];
+    }
+
+    get languageMap(): Record<string, string> {
+        return this.ini["LanguageMap"] ?? {};
+    }
+
+    get minimumValidYear(): number {
+        return parseInt(this.ini["minimum_valid_year"] ?? 1000);
+    }
 }
 
 export default PrivateConfig;

--- a/api/src/services/DateSanitizer.ts
+++ b/api/src/services/DateSanitizer.ts
@@ -21,6 +21,7 @@ export default class DateSanitizer {
             "1888-05-99",
             "1888/05/12",
             "1888--05--12",
+            "693-01-07",
         ];
         for (const date of tests) {
             console.log(date, DateSanitizer.sanitize(date));
@@ -62,7 +63,8 @@ export default class DateSanitizer {
         }
 
         // If we've gotten this far, we at least know that we have a valid year.
-        const year = date.substr(0, 4);
+        const yearValue = "0000" + parseInt(date.substr(0, 4));
+        const year = yearValue.substr(yearValue.length - 4, 4);
 
         // Let's get rid of punctuation and normalize separators:
         date = date.replace(/[. ?]/g, "").replace(/\/|--|0-/g, "-");

--- a/api/src/services/SolrIndexer.ts
+++ b/api/src/services/SolrIndexer.ts
@@ -1,3 +1,4 @@
+import Config from "../models/Config";
 import DateSanitizer from "./DateSanitizer";
 import Fedora from "./Fedora";
 import FedoraData from "../models/FedoraData";
@@ -9,126 +10,17 @@ interface SolrFields {
 
 class SolrIndexer {
     hierarchyCollector: HierarchyCollector;
-    // TODO: make configurable
-    institution = "Villanova University";
-    collection = "Digital Library";
 
     constructor() {
         // Make Fedora connection
         const fedora = new Fedora();
-        // TODO: make configurable
-        const topPids = ["vudl:1", "vudl:3"];
-        this.hierarchyCollector = new HierarchyCollector(fedora, topPids);
+        this.hierarchyCollector = new HierarchyCollector(fedora, Config.getInstance().topLevelPids);
     }
 
     protected padNumber(num: string): string {
         // Yes, I wrote a left_pad function.
         const paddedNumber = "0000000000" + num;
         return paddedNumber.substr(paddedNumber.length - 10);
-    }
-
-    protected getLanguageMap(): Record<string, string> {
-        // TODO: make configurable
-        return {
-            ab: "Abkhazian",
-            af: "Afrikaans",
-            an: "Aragonese",
-            ar: "Arabic",
-            as: "Assamese",
-            az: "Azerbaijani",
-            be: "Belarusian",
-            bg: "Bulgarian",
-            bn: "Bengali",
-            bo: "Tibetan",
-            br: "Breton",
-            bs: "Bosnian",
-            ca: "Catalan / Valencian",
-            ce: "Chechen",
-            co: "Corsican",
-            cs: "Czech",
-            cu: "Church Slavic",
-            cy: "Welsh",
-            da: "Danish",
-            de: "German",
-            el: "Greek",
-            en: "English",
-            eo: "Esperanto",
-            es: "Spanish / Castilian",
-            et: "Estonian",
-            eu: "Basque",
-            fa: "Persian",
-            fi: "Finnish",
-            fj: "Fijian",
-            fo: "Faroese",
-            fr: "French",
-            fy: "Western Frisian",
-            ga: "Irish",
-            gd: "Gaelic / Scottish Gaelic",
-            gl: "Galician",
-            grc: "Ancient Greek",
-            gv: "Manx",
-            he: "Hebrew",
-            hi: "Hindi",
-            hr: "Croatian",
-            ht: "Haitian; Haitian Creole",
-            hu: "Hungarian",
-            hy: "Armenian",
-            id: "Indonesian",
-            is: "Icelandic",
-            it: "Italian",
-            ja: "Japanese",
-            jv: "Javanese",
-            ka: "Georgian",
-            kg: "Kongo",
-            ko: "Korean",
-            ku: "Kurdish",
-            kw: "Cornish",
-            ky: "Kirghiz",
-            la: "Latin",
-            lb: "Luxembourgish; Letzeburgesch",
-            li: "Limburgan; Limburger; Limburgish",
-            ln: "Lingala",
-            lt: "Lithuanian",
-            lv: "Latvian",
-            mg: "Malagasy",
-            mk: "Macedonian",
-            mn: "Mongolian",
-            mo: "Moldavian",
-            ms: "Malay",
-            mt: "Maltese",
-            my: "Burmese",
-            nb: "Norwegian (Bokmål)",
-            ne: "Nepali",
-            nl: "Dutch",
-            nn: "Norwegian (Nynorsk)",
-            no: "Norwegian",
-            oc: "Occitan (post 1500); Provençal",
-            pl: "Polish",
-            pt: "Portuguese",
-            rm: "Raeto-Romance",
-            ro: "Romanian",
-            ru: "Russian",
-            sc: "Sardinian",
-            se: "Northern Sami",
-            sk: "Slovak",
-            sl: "Slovenian",
-            so: "Somali",
-            sq: "Albanian",
-            sr: "Serbian",
-            sv: "Swedish",
-            sw: "Swahili",
-            tk: "Turkmen",
-            tr: "Turkish",
-            ty: "Tahitian",
-            uk: "Ukrainian",
-            ur: "Urdu",
-            uz: "Uzbek",
-            vi: "Vietnamese",
-            vo: "Volapuk",
-            yi: "Yiddish",
-            zh: "Chinese",
-            "pt-BR": "Portuguese (Brazilian)",
-        };
     }
 
     async getFields(pid: string): Promise<SolrFields> {
@@ -139,8 +31,8 @@ class SolrIndexer {
         const fields: SolrFields = {
             id: pid,
             record_format: "vudl",
-            institution: this.institution,
-            collection: this.collection,
+            institution: Config.getInstance().institution,
+            collection: Config.getInstance().collection,
             modeltype_str_mv: fedoraData.models,
             datastream_str_mv: fedoraData.fedoraDatastreams,
             hierarchytype: "",
@@ -302,8 +194,7 @@ class SolrIndexer {
             ? (hierarchyParents[0].metadata["dc:date"] ?? [])[0] ?? ""
             : (fields["dc.date_txt_mv"] ?? [])[0] ?? "";
         const strippedDate = dateString.substr(0, 4);
-        // TODO: configurable date cut-off?
-        if (parseInt(strippedDate) > 1000) {
+        if (parseInt(strippedDate) > Config.getInstance().minimumValidYear) {
             fields.publishDate = strippedDate;
             fields.publishDateSort = strippedDate;
             fields.normalized_sort_date = DateSanitizer.sanitize(dateString);
@@ -311,15 +202,14 @@ class SolrIndexer {
 
         if (typeof fields["dc.language_txt_mv"] !== "undefined") {
             fields.language = (fields["dc.language_txt_mv"] as Array<string>).map((lang) => {
-                return this.getLanguageMap()[lang] ?? lang;
+                return Config.getInstance().languageMap[lang] ?? lang;
             });
         }
 
         if (typeof fields["title"] !== "undefined") {
-            // TODO: configurable article list:
-            const articles = ["a ", "an ", "the "];
+            // If we have a title, generate a sort-friendly version:
             let sortTitle = (fields["title"] as string).toLowerCase();
-            for (const article of articles) {
+            for (const article of Config.getInstance().articlesToStrip) {
                 if (sortTitle.substr(0, article.length) === article) {
                     sortTitle = sortTitle.substr(article.length);
                     break;

--- a/api/src/services/SolrIndexer.ts
+++ b/api/src/services/SolrIndexer.ts
@@ -193,10 +193,10 @@ class SolrIndexer {
         const dateString = fedoraData.models.includes("vudl-system:DataModel")
             ? (hierarchyParents[0].metadata["dc:date"] ?? [])[0] ?? ""
             : (fields["dc.date_txt_mv"] ?? [])[0] ?? "";
-        const strippedDate = dateString.substr(0, 4);
-        if (parseInt(strippedDate) > Config.getInstance().minimumValidYear) {
-            fields.publishDate = strippedDate;
-            fields.publishDateSort = strippedDate;
+        const strippedDate = parseInt(dateString.substr(0, 4));
+        if (strippedDate > Config.getInstance().minimumValidYear) {
+            fields.publishDate = String(strippedDate);
+            fields.publishDateSort = String(strippedDate);
             fields.normalized_sort_date = DateSanitizer.sanitize(dateString);
         }
 

--- a/api/vudl.ini.dist
+++ b/api/vudl.ini.dist
@@ -10,7 +10,6 @@ base_url = "http://localhost:8080/rest"
 # The first number for the PID generator to use:
 fedora_initial_pid = "1"
 
-# URL for the VuFind Solr used for indexing the collection:
 solr_query_url = "http://myserver:8983/solr/core/query"
 
 # Values to be indexed into commonly-used Solr facet fields:

--- a/api/vudl.ini.dist
+++ b/api/vudl.ini.dist
@@ -75,7 +75,9 @@ allowed_origins[] = http://localhost:9000 # client
 # The lowest number recognized as a legal year during indexing
 minimum_valid_year = 1000
 
-# Articles that should be stripped from the title sort field during indexing
+# Articles that should be stripped from the title sort field during indexing.
+# Be sure to include a trailing space if the articles are whole words.
+# These should always be entered in all-lowercase, as sort text will be lowercased.
 articles_to_strip[] = "a "
 articles_to_strip[] = "an "
 articles_to_strip[] = "the "

--- a/api/vudl.ini.dist
+++ b/api/vudl.ini.dist
@@ -1,4 +1,4 @@
-# URLs of VuDL API and React client
+# URL of React client:
 client_url = "http://localhost:3000"
 
 # Credentials for connecting to a Fedora backend:
@@ -10,7 +10,18 @@ base_url = "http://localhost:8080/rest"
 # The first number for the PID generator to use:
 fedora_initial_pid = "1"
 
+# URL for the VuFind Solr used for indexing the collection:
 solr_query_url = "http://myserver:8983/solr/core/query"
+
+# Values to be indexed into commonly-used Solr facet fields:
+institution = "My University"
+collection = "Digital Library"
+
+# Top-level PIDs (used to determine the end of the chain when retrieving parents)
+# This is commonly the PID of your very top-level object -- e.g. vudl:1 -- and
+# the PID of your top-level public object -- e.g. vudl:3.
+top_level_pids[] = "vudl:1"
+top_level_pids[] = "vudl:3"
 
 # Settings for Tesseract OCR
 tesseract_path = "/usr/local/bin/tesseract"
@@ -52,11 +63,121 @@ textcleaner_switches = "-g -e stretch -u -T"
 # Base path where incoming files are stored; this must contain two levels
 # of subdirectories, the first representing categories and the second
 # representing jobs within those categories.
-holding_area_path = "C:/holdingarea"
+holding_area_path = "/opt/holdingarea"
 
 # Base path where processed files are moved after ingestion.
-processed_area_path = "C:/processed"
+processed_area_path = "/opt/processed"
 
 # Allowed origins, IPs, and addresses for CORS
 allowed_origins[] = http://localhost:3000 # api
 allowed_origins[] = http://localhost:9000 # client
+
+# The lowest number recognized as a legal year during indexing
+minimum_valid_year = 1000
+
+# Articles that should be stripped from the title sort field during indexing
+articles_to_strip[] = "a "
+articles_to_strip[] = "an "
+articles_to_strip[] = "the "
+
+# Mapping of language codes to display names; used for indexing
+[LanguageMap]
+ab = Abkhazian
+af = Afrikaans
+an = Aragonese
+ar = Arabic
+as = Assamese
+az = Azerbaijani
+be = Belarusian
+bg = Bulgarian
+bn = Bengali
+bo = Tibetan
+br = Breton
+bs = Bosnian
+ca = Catalan / Valencian
+ce = Chechen
+co = Corsican
+cs = Czech
+cu = Church Slavic
+cy = Welsh
+da = Danish
+de = German
+el = Greek
+en = English
+eo = Esperanto
+es = Spanish / Castilian
+et = Estonian
+eu = Basque
+fa = Persian
+fi = Finnish
+fj = Fijian
+fo = Faroese
+fr = French
+fy = Western Frisian
+ga = Irish
+gd = Gaelic / Scottish Gaelic
+gl = Galician
+grc = Ancient Greek
+gv = Manx
+he = Hebrew
+hi = Hindi
+hr = Croatian
+ht = Haitian; Haitian Creole
+hu = Hungarian
+hy = Armenian
+id = Indonesian
+is = Icelandic
+it = Italian
+ja = Japanese
+jv = Javanese
+ka = Georgian
+kg = Kongo
+ko = Korean
+ku = Kurdish
+kw = Cornish
+ky = Kirghiz
+la = Latin
+lb = Luxembourgish; Letzeburgesch
+li = Limburgan; Limburger; Limburgish
+ln = Lingala
+lt = Lithuanian
+lv = Latvian
+mg = Malagasy
+mk = Macedonian
+mn = Mongolian
+mo = Moldavian
+ms = Malay
+mt = Maltese
+my = Burmese
+nb = Norwegian (Bokmål)
+ne = Nepali
+nl = Dutch
+nn = Norwegian (Nynorsk)
+no = Norwegian
+oc = Occitan (post 1500); Provençal
+pl = Polish
+pt = Portuguese
+pt-BR = Portuguese (Brazilian)
+rm = Raeto-Romance
+ro = Romanian
+ru = Russian
+sc = Sardinian
+se = Northern Sami
+sk = Slovak
+sl = Slovenian
+so = Somali
+sq = Albanian
+sr = Serbian
+sv = Swedish
+sw = Swahili
+tk = Turkmen
+tr = Turkish
+ty = Tahitian
+uk = Ukrainian
+ur = Urdu
+uz = Uzbek
+vi = Vietnamese
+vo = Volapuk
+yi = Yiddish
+zh = Chinese
+


### PR DESCRIPTION
This resolves all outstanding TODO items on the Solr indexing tool. It also makes date handling a little more flexible/tolerant (to support less than 4-digit years) and improves some existing .ini comments.