### PR TITLE
Reload when the .ini file changes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "api": "node api/bin/www",
     "api:build": "cd api && tsc",
-    "api:dev": "nodemon --watch 'api/**/*.js' --watch 'api/**/*.ejs' --ignore api/node_modules/ api/bin/www",
+    "api:dev": "nodemon --watch 'api/vudl.ini' --watch 'api/**/*.js' --watch 'api/**/*.ejs' --ignore api/node_modules/ api/bin/www",
     "api:lint": "eslint api/*.js api/src/ --ext .ts,.js,.jsx",
     "api:setup": "cd api && npm ci",
     "api:watch": "cd api && tsc --watch",
@@ -19,7 +19,7 @@
     "client:lint": "eslint client/src/ --ext .ts,.js,.jsx",
     "client:setup": "cd client && npm ci",
     "queue": "node api/worker-start.js",
-    "queue:dev": "nodemon --watch 'api/**/*.js' api/worker-start.js",
+    "queue:dev": "nodemon --watch 'api/vudl.ini' --watch 'api/**/*.js' api/worker-start.js",
     "queue:wsl": "nodemon --legacy-watch api/worker-start.js",
     "ingest": "node api/scripts/ingest.js",
     "backend": "concurrently npm:api npm:queue",


### PR DESCRIPTION
This makes it possible for .ini file changes to immediately take effect, instead of requiring a manual restart of the dev server.