### PR TITLE
Remove redundant, unused Solr setting.

### DIFF
--- a/api/src/models/PrivateConfig.ts
+++ b/api/src/models/PrivateConfig.ts
@@ -21,10 +21,6 @@ class PrivateConfig {
         return this.ini["fedora_pid_namespace"];
     }
 
-    get solrQueryUrl(): string {
-        return this.ini["solr_query_url"];
-    }
-
     get ffmpegPath(): string {
         return this.ini["ffmpeg_path"];
     }

--- a/api/vudl.ini.dist
+++ b/api/vudl.ini.dist
@@ -10,8 +10,6 @@ base_url = "http://localhost:8080/rest"
 # The first number for the PID generator to use:
 fedora_initial_pid = "1"
 
-solr_query_url = "http://myserver:8983/solr/core/query"
-
 # Settings for Tesseract OCR
 tesseract_path = "/usr/local/bin/tesseract"
 


### PR DESCRIPTION
This value can be derived from other existing settings, so I don't think we need to keep it as a separate config.