### PR TITLE
Write FITS XML to disk instead of using passthrough.

### DIFF
--- a/api/src/models/FedoraObject.ts
+++ b/api/src/models/FedoraObject.ts
@@ -123,8 +123,15 @@ export class FedoraObject {
     }
 
     fitsMasterMetadata(filename: string): string {
-        const fitsCommand = Config.getInstance().fitsCommand + " -i " + filename;
-        return execSync(fitsCommand).toString();
+        const targetXml = filename + ".fits.xml";
+        if (!fs.existsSync(targetXml)) {
+            const fitsCommand = Config.getInstance().fitsCommand + " -i " + filename + " -o " + targetXml;
+            execSync(fitsCommand);
+            if (!fs.existsSync(targetXml)) {
+                throw new Error("FITS failed to create " + targetXml);
+            }
+        }
+        return fs.readFileSync(targetXml).toString();
     }
 
     async imageDataIngest(): Promise<void> {


### PR DESCRIPTION
This pull request addresses two problems I encountered while testing audio files:

1.) Some of the tools used by FITS put random output into stdout, which means that capturing the console output does not give pure, reliable XML -- writing a file to disk is much more reliable.

2.) FITS can be very slow -- this allows us to cache the results in our holding area, so if we rebuild jobs repeatedly, we don't have to wait. Could also be useful for debugging if something goes wrong.