### PR TITLE
Log job queue errors.

### DIFF
--- a/api/src/services/JobQueue.ts
+++ b/api/src/services/JobQueue.ts
@@ -1,4 +1,4 @@
-import { Worker } from "bullmq";
+import { Job, Worker } from "bullmq";
 
 // TODO: Maybe don't load all of them?
 import Derivative from "../jobs/Derivative";

--- a/api/src/services/JobQueue.ts
+++ b/api/src/services/JobQueue.ts
@@ -26,7 +26,7 @@ class JobQueue {
 
             return await this.workers[job.name].run(job);
         });
-        this.manager.on("failed", (job: Job, failedReason: string) {
+        this.manager.on("failed", (job: Job, failedReason: string) => {
             console.error("Job failed; reason: " + failedReason);
         });
 

--- a/api/src/services/JobQueue.ts
+++ b/api/src/services/JobQueue.ts
@@ -26,6 +26,9 @@ class JobQueue {
 
             return await this.workers[job.name].run(job);
         });
+        this.manager.on("failed", (job: Job, failedReason: string) {
+            console.error("Job failed; reason: " + failedReason);
+        });
 
         console.log("JobQueue started");
     }


### PR DESCRIPTION
This makes it easier to troubleshoot job queueing problems, since they show up in the log.