### PR TITLE
Fix warning in test suite.

### DIFF
--- a/client/src/useJobPaginator.test.js
+++ b/client/src/useJobPaginator.test.js
@@ -141,8 +141,8 @@ describe("useJobPaginator", () => {
                 ]);
             });
 
-            act(() => {
-                result.current.action.deletePage();
+            await act(async () => {
+                await result.current.action.deletePage();
             });
 
             expect(JobPaginatorState.deletePageValidation).toHaveBeenCalled;


### PR DESCRIPTION
@diboy2, I noticed that there were two warnings in the test suite. This PR fixes one of them. The other is:

<pre>
    console.error
      Warning: <mock-JobClickable /> is using incorrect casing. Use PascalCase for React components, or lowercase for HTML elements.
          in mock-JobClickable (at Job.test.js:14)
          in JobClickable (at Job.jsx:24)
          in li (at Job.jsx:23)
          in Job (at Job.test.js:33)
          in Context.Provider (at context.js:34)
          in FetchContextProvider (at Job.test.js:32)

      at printWarning (node_modules/react-dom/cjs/react-dom-server.node.development.js:102:30)
      at error (node_modules/react-dom/cjs/react-dom-server.node.development.js:74:5)
      at ReactDOMServerRenderer.renderDOM (node_modules/react-dom/cjs/react-dom-server.node.development.js:3762:11)
      at ReactDOMServerRenderer.render (node_modules/react-dom/cjs/react-dom-server.node.development.js:3484:21)
      at ReactDOMServerRenderer.read (node_modules/react-dom/cjs/react-dom-server.node.development.js:3373:29)
      at Object.renderToStaticMarkup (node_modules/react-dom/cjs/react-dom-server.node.development.js:4004:27)
      at Object.render (node_modules/enzyme-adapter-react-16/src/ReactSixteenAdapter.js:836:31)
      at render (node_modules/enzyme/src/render.js:21:25)
</pre>

...but I'm less sure about how to fix that, since I'm not familiar with the process of mocking components, and so I'm not sure where the unconventional name is coming from, or how easily it can be changed. Any thoughts?