### PR TITLE
Remove api:watch npm script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ After a few moments, a new tab should automatically open in your browser pointin
 | api:dev | run api server, restart server on changes |
 | api:lint | lint only the api code |
 | api:setup | install npm dependencies in api/ |
-| api:watch | run Typescript in watch mode on api code |
 | api:wsl | run api server, restart on changes (use if on WSL or `api:dev` isn't working) |
 | | |
 | client | run react-scripts server |

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "api:setup": "cd api && npm ci",
     "api:test": "cd api && npm test",
     "api:testWatch": "cd api && npm run testWatch",
-    "api:watch": "cd api && tsc --watch",
     "api:wsl": "nodemon --legacy-watch api/bin/www",
     "client": "cd client && npm run prod",
     "client:build": "cd client && npm run build",


### PR DESCRIPTION
The `api:watch` NPM script was set up to recompile the API code upon changes, and used to need to be run in parallel with the `dev` script to have a running dev environment that would automatically update itself upon code changes. Since @diboy2 has streamlined some configurations, the `dev` task now handles watching for changes by itself, and `api:watch` is no longer needed (in fact, it currently causes tests to break by generating an unneeded `dist` directory).

This PR removes the obsolete script.