### PR TITLE
Turn on next.js ESLint rules.

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -18,7 +18,8 @@
       {
         "usePrettierrc": true
       }
-    ]
+    ],
+    "react-hooks/exhaustive-deps": "off"
   },
   "settings": {
     "react": {

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -9,7 +9,7 @@
     "sourceType": "module"
   },
   "plugins": ["react"],
-  "extends": ["eslint:recommended", "plugin:prettier/recommended", "plugin:react/recommended"],
+  "extends": ["next", "eslint:recommended", "plugin:prettier/recommended", "plugin:react/recommended"],
   "rules": {
     "prettier/prettier": [
       "error",

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -11,6 +11,7 @@
   "plugins": ["react"],
   "extends": ["next", "eslint:recommended", "plugin:prettier/recommended", "plugin:react/recommended"],
   "rules": {
+    "@next/next/no-img-element": "off",
     "prettier/prettier": [
       "error",
       {},


### PR DESCRIPTION
This pull request turns on next.js ESLint rules.

I've disabled the "use Image instead of img" rule for now because I think it adds complexity we don't necessarily need.

I spent nearly an hour trying to figure out how to resolve `react-hooks/exhaustive-deps`, but I clearly don't understand all of the implications, because every time I make lint happy, I actually break the code and cause infinite AJAX reloads and similar problems. I get the impression that this is actually highlighting an important issue that we need to clean up, but I don't think my understanding of hooks is deep enough to actually fix it properly. Any advice, @diboy2?

(For the record, my first attempted solution was to simply add all the missing dependencies as suggested... but that clearly causes effects to trigger more frequently than we want them to; I next tried incorporating useCallback, but that didn't help either...).

TODO:
- [x] Resolve outstanding issues.