### PR TITLE
Make VuFind URL optional for indexing.

### DIFF
--- a/api/src/models/Config.ts
+++ b/api/src/models/Config.ts
@@ -53,7 +53,7 @@ class Config {
     }
 
     get vufindUrl(): string {
-        return this.ini["vufind_url"];
+        return this.ini["vufind_url"] ?? "";
     }
 
     get pdfDirectory(): string {

--- a/api/src/services/SolrIndexer.ts
+++ b/api/src/services/SolrIndexer.ts
@@ -41,6 +41,10 @@ class SolrIndexer {
 
     protected async getChangeTrackerDetails(pid: string, modificationDate: string): Promise<Record<string, string>> {
         const core = this.config.solrCore;
+        if (!this.config.vufindUrl) {
+            console.warn("No VuFind URL configured; skipping change tracking indexing.");
+            return {};
+        }
         const url = this.config.vufindUrl + "/XSLT/Home?";
         const query =
             "method[]=getLastIndexed&method[]=getFirstIndexed&id=" +
@@ -326,8 +330,12 @@ class SolrIndexer {
             pid,
             fields["fgs.lastModifiedDate_txt_mv"][0] ?? "1900-01-01T00:00:00Z"
         );
-        fields.first_indexed = change.getFirstIndexed;
-        fields.last_indexed = change.getLastIndexed;
+        if (change.getFirstIndexed ?? "") {
+            fields.first_indexed = change.getFirstIndexed;
+        }
+        if (change.getLastIndexed ?? "") {
+            fields.last_indexed = change.getLastIndexed;
+        }
 
         return fields;
     }

--- a/api/vudl.ini.dist
+++ b/api/vudl.ini.dist
@@ -30,7 +30,9 @@ tesseract_path = "/usr/local/bin/tesseract"
 # Settings for ocrmypdf (omit setting to skip this step if you aren't using it)
 #ocrmypdf_path = /usr/local/bin/ocrmypdf
 
-# VuFind Base URL
+# VuFind Base URL. Required for indexing first/last change dates into Solr and
+# for generating PDFs for existing items in the collection. You can omit the
+# setting if you do not use VuFind and do not need these features.
 vufind_url = "https://myserver"
 
 # Base URL and core name for Solr instance containing index


### PR DESCRIPTION
This should make it easier for @diboy2 (or anyone else) to test the system without having to either fully configure VuFind or else comment out VuFind-specific code in the indexer. Now we can just unset the setting and it will omit unsupported data gracefully.