### PR TITLE
Handle Follow messages from Camel Toolbox.

### DIFF
--- a/api/src/routes/messenger.ts
+++ b/api/src/routes/messenger.ts
@@ -70,6 +70,9 @@ messenger.post("/camel", bodyParser.json(), async function (req, res) {
         case "Purge":
             await QueueManager.getInstance().performIndexOperation(pid, "delete");
             break;
+        case "Follow":
+            // Follow messages do not require any action at this time.
+            break;
         default: {
             const msg = "Unexpected action: " + action + " (on PID: " + pid + ")";
             console.error(msg);


### PR DESCRIPTION
I've just encountered a new type of message coming from the Camel Toolbox, caused by the creation of certain types of relationships. (When resource B is assigned certain triples that refer to resource A, then resource A receives a Follow event). I think this is happening as a result of changes in #98, since we are expressing more object relationships in RDF instead of the RELS-EXT datastream. In any case, I do not believe that we need to trigger a reindex in these situations, so this PR simply ignores the messages to avoid filling the console with warnings.