### PR TITLE
Create test coverage for substring calls

### DIFF
--- a/api/src/jobs/Ingest.test.ts
+++ b/api/src/jobs/Ingest.test.ts
@@ -61,29 +61,22 @@ describe("IngestProcessor", () => {
     });
     describe("moveDirectory", () => {
         it("moves the directory appropriately", () => {
-            const date = new Date();
-            const month = "0" + (date.getMonth() + 1);
-            const day = "0" + date.getDate();
-            const expectedTargetParent =
-                "/fake_processed/" +
-                date.getFullYear() +
-                "-" +
-                month.substring(month.length - 2) +
-                "-" +
-                day.substring(day.length - 2) +
-                "/fake";
+            const expectedTargetParent = "/fake_processed/2\\d\\d\\d-\\d\\d-\\d\\d/fake";
+            const expectedTargetParentRegEx = new RegExp(expectedTargetParent);
             const expectedTarget = expectedTargetParent + "/fakejob";
+            const expectedTargetRegEx = new RegExp(expectedTarget);
+            const expectedLockRegEx = new RegExp(expectedTarget + "/ingest.lock");
             const existsSpy = jest.spyOn(fs, "existsSync").mockReturnValueOnce(false).mockReturnValueOnce(true);
             const renameSpy = jest.spyOn(fs, "renameSync").mockImplementation(jest.fn());
             const unlinkSpy = jest.spyOn(fs, "unlinkSync").mockImplementation(jest.fn());
             ingest.moveDirectory();
             expect(existsSpy).toHaveBeenCalledTimes(2);
-            expect(existsSpy).toHaveBeenNthCalledWith(1, expectedTarget);
-            expect(existsSpy).toHaveBeenNthCalledWith(2, expectedTargetParent);
+            expect(existsSpy).toHaveBeenNthCalledWith(1, expect.stringMatching(expectedTargetRegEx));
+            expect(existsSpy).toHaveBeenNthCalledWith(2, expect.stringMatching(expectedTargetParentRegEx));
             expect(renameSpy).toHaveBeenCalledTimes(1);
-            expect(renameSpy).toHaveBeenCalledWith(job.dir, expectedTarget);
+            expect(renameSpy).toHaveBeenCalledWith(job.dir, expect.stringMatching(expectedTargetRegEx));
             expect(unlinkSpy).toHaveBeenCalledTimes(1);
-            expect(unlinkSpy).toHaveBeenCalledWith(expectedTarget + "/ingest.lock");
+            expect(unlinkSpy).toHaveBeenCalledWith(expect.stringMatching(expectedLockRegEx));
         });
     });
 });

--- a/api/src/jobs/Ingest.test.ts
+++ b/api/src/jobs/Ingest.test.ts
@@ -27,9 +27,7 @@ describe("IngestProcessor", () => {
         config = new Config({});
         logger = winston.createLogger({
             level: "error", // we don't want to see info messages while testing
-            transports: [
-                new winston.transports.Console(),
-            ],
+            transports: [new winston.transports.Console()],
         });
         fedora = new Fedora(config);
         job = new Job(dir + "/" + jobName, config, new QueueManager());
@@ -43,7 +41,9 @@ describe("IngestProcessor", () => {
         it("creates a title based on the directory path", async () => {
             const fedoraObject = new FedoraObject("foo:123", config, fedora);
             const labelSpy = jest.spyOn(fedoraObject, "modifyObjectLabel").mockImplementation(jest.fn());
-            const datastreamSpy = jest.spyOn(fedoraObject, "getDatastream").mockResolvedValue("<oai:dc><dc:title>Incomplete... / Processing...</dc:title></oai:dc>");
+            const datastreamSpy = jest
+                .spyOn(fedoraObject, "getDatastream")
+                .mockResolvedValue("<oai:dc><dc:title>Incomplete... / Processing...</dc:title></oai:dc>");
             const replaceSpy = jest.spyOn(ingest, "replaceDCMetadata").mockImplementation(jest.fn());
             await ingest.finalizeTitle(fedoraObject);
             expect(labelSpy).toHaveBeenCalledTimes(1);
@@ -51,7 +51,11 @@ describe("IngestProcessor", () => {
             expect(datastreamSpy).toHaveBeenCalledTimes(1);
             expect(datastreamSpy).toHaveBeenCalledWith("DC");
             expect(replaceSpy).toHaveBeenCalledTimes(1);
-            expect(replaceSpy).toHaveBeenCalledWith(fedoraObject, "<oai:dc><dc:title>fakejob_dir_fake_my</dc:title></oai:dc>", "Set dc:title to ingest/process path");
+            expect(replaceSpy).toHaveBeenCalledWith(
+                fedoraObject,
+                "<oai:dc><dc:title>fakejob_dir_fake_my</dc:title></oai:dc>",
+                "Set dc:title to ingest/process path"
+            );
         });
     });
 });

--- a/api/src/jobs/Ingest.test.ts
+++ b/api/src/jobs/Ingest.test.ts
@@ -62,9 +62,16 @@ describe("IngestProcessor", () => {
     describe("moveDirectory", () => {
         it("moves the directory appropriately", () => {
             const date = new Date();
-            const month = ("0" + (date.getMonth() + 1));
-            const day = ("0" + date.getDate());
-            const expectedTargetParent = "/fake_processed/" + date.getFullYear() + "-" + month.substring(month.length - 2) + "-" + day.substring(day.length - 2) + "/fake";
+            const month = "0" + (date.getMonth() + 1);
+            const day = "0" + date.getDate();
+            const expectedTargetParent =
+                "/fake_processed/" +
+                date.getFullYear() +
+                "-" +
+                month.substring(month.length - 2) +
+                "-" +
+                day.substring(day.length - 2) +
+                "/fake";
             const expectedTarget = expectedTargetParent + "/fakejob";
             const existsSpy = jest.spyOn(fs, "existsSync").mockReturnValueOnce(false).mockReturnValueOnce(true);
             const renameSpy = jest.spyOn(fs, "renameSync").mockImplementation(jest.fn());
@@ -78,5 +85,5 @@ describe("IngestProcessor", () => {
             expect(unlinkSpy).toHaveBeenCalledTimes(1);
             expect(unlinkSpy).toHaveBeenCalledWith(expectedTarget + "/ingest.lock");
         });
-    })
+    });
 });

--- a/api/src/jobs/Ingest.test.ts
+++ b/api/src/jobs/Ingest.test.ts
@@ -1,0 +1,57 @@
+import Config from "../models/Config";
+import Job from "../models/Job";
+import { FedoraObject } from "../models/FedoraObject";
+import Fedora from "../services/Fedora";
+import FedoraObjectFactory from "../services/FedoraObjectFactory";
+import { IngestProcessor } from "./Ingest";
+import QueueManager from "../services/QueueManager";
+import winston = require("winston");
+
+// We have an indirect dependency on ImageFile, but we don't really want
+// to load it for the context of this test.
+jest.mock("../models/ImageFile.ts", () => {
+    return {};
+});
+
+describe("IngestProcessor", () => {
+    let ingest: IngestProcessor;
+    let config: Config;
+    let logger: winston.Logger;
+    let dir: string;
+    let jobName: string;
+    let fedora: Fedora;
+    let job: Job;
+    beforeEach(() => {
+        dir = "/my/fake/dir";
+        jobName = "fakejob";
+        config = new Config({});
+        logger = winston.createLogger({
+            level: "error", // we don't want to see info messages while testing
+            transports: [
+                new winston.transports.Console(),
+            ],
+        });
+        fedora = new Fedora(config);
+        job = new Job(dir + "/" + jobName, config, new QueueManager());
+        jest.spyOn(Job, "build").mockReturnValue(job);
+        ingest = new IngestProcessor(dir, config, new FedoraObjectFactory(config), logger);
+    });
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+    describe("finalizeTitle", () => {
+        it("creates a title based on the directory path", async () => {
+            const fedoraObject = new FedoraObject("foo:123", config, fedora);
+            const labelSpy = jest.spyOn(fedoraObject, "modifyObjectLabel").mockImplementation(jest.fn());
+            const datastreamSpy = jest.spyOn(fedoraObject, "getDatastream").mockResolvedValue("<oai:dc><dc:title>Incomplete... / Processing...</dc:title></oai:dc>");
+            const replaceSpy = jest.spyOn(ingest, "replaceDCMetadata").mockImplementation(jest.fn());
+            await ingest.finalizeTitle(fedoraObject);
+            expect(labelSpy).toHaveBeenCalledTimes(1);
+            expect(labelSpy).toHaveBeenCalledWith("fakejob_dir_fake_my");
+            expect(datastreamSpy).toHaveBeenCalledTimes(1);
+            expect(datastreamSpy).toHaveBeenCalledWith("DC");
+            expect(replaceSpy).toHaveBeenCalledTimes(1);
+            expect(replaceSpy).toHaveBeenCalledWith(fedoraObject, "<oai:dc><dc:title>fakejob_dir_fake_my</dc:title></oai:dc>", "Set dc:title to ingest/process path");
+        });
+    });
+});

--- a/api/src/jobs/Ingest.ts
+++ b/api/src/jobs/Ingest.ts
@@ -15,19 +15,23 @@ import QueueJobInterface from "./QueueJobInterface";
 import winston = require("winston");
 import xmlescape = require("xml-escape");
 
-class IngestProcessor {
+export class IngestProcessor {
     protected job: Job;
     protected category: Category;
     protected logger: winston.Logger;
     protected config: Config;
     protected objectFactory: FedoraObjectFactory;
 
-    constructor(dir: string, config: Config, objectFactory: FedoraObjectFactory) {
+    constructor(dir: string, config: Config, objectFactory: FedoraObjectFactory, logger: winston.Logger) {
         this.config = config;
         this.objectFactory = objectFactory;
         this.job = Job.build(dir);
         this.category = new Category(path.dirname(dir));
-        this.logger = winston.createLogger({
+        this.logger = logger;
+    }
+
+    public static build(dir: string): IngestProcessor {
+        const logger = winston.createLogger({
             level: "info",
             format: winston.format.combine(
                 winston.format.timestamp(),
@@ -38,10 +42,7 @@ class IngestProcessor {
                 new winston.transports.Console(),
             ],
         });
-    }
-
-    public static build(dir: string): IngestProcessor {
-        return new IngestProcessor(dir, Config.getInstance(), FedoraObjectFactory.getInstance());
+        return new IngestProcessor(dir, Config.getInstance(), FedoraObjectFactory.getInstance(), logger);
     }
 
     async addDatastreamsToPage(page: Page, imageData: FedoraObject): Promise<void> {

--- a/api/src/models/ImageFile.test.ts
+++ b/api/src/models/ImageFile.test.ts
@@ -10,10 +10,14 @@ jest.mock("jimp", () => {
 describe("Image", () => {
     let image: ImageFile;
     beforeEach(() => {
-        image = new ImageFile("test1", new Config({}));
+        image = new ImageFile("test1.tif", new Config({}));
     });
 
     it("should return the filename", () => {
-        expect(image.filename).toEqual("test1");
+        expect(image.filename).toEqual("test1.tif");
+    });
+
+    it("generates appropriate derivative paths", () => {
+        expect(image.derivativePath("HUGE", "gif")).toEqual("./test1/HUGE/test1.gif");
     });
 });

--- a/api/src/models/ImageFile.test.ts
+++ b/api/src/models/ImageFile.test.ts
@@ -10,14 +10,14 @@ jest.mock("jimp", () => {
 describe("Image", () => {
     let image: ImageFile;
     beforeEach(() => {
-        image = new ImageFile("test1.tif", new Config({}));
+        image = new ImageFile("/foo/test1.tif", new Config({}));
     });
 
     it("should return the filename", () => {
-        expect(image.filename).toEqual("test1.tif");
+        expect(image.filename).toEqual("/foo/test1.tif");
     });
 
     it("generates appropriate derivative paths", () => {
-        expect(image.derivativePath("HUGE", "gif")).toEqual("./test1/HUGE/test1.gif");
+        expect(image.derivativePath("HUGE", "gif")).toEqual("/foo/test1/HUGE/test1.gif");
     });
 });

--- a/api/src/services/DateSanitizer.test.ts
+++ b/api/src/services/DateSanitizer.test.ts
@@ -16,6 +16,7 @@ describe("DateSanitizer", () => {
         ["1888-05-99", "1888-05-01T00:00:00Z", "Year-month-illegal day, numeric format"],
         ["1888--05--12", "1888-05-12T00:00:00Z", "Year--month--day, with double dashes"],
         ["693-01-07", "0693-01-01T00:00:00Z", "Year-month-day, with three-digit year"],
+        ["693-1-7", "0693-01-01T00:00:00Z", "Year-month-day, with no leading zeroes"],
     ])("DateSanitizer.sanitize(%s) => %s. Description: %s", (testInput, expectedValue) => {
         expect(DateSanitizer.sanitize(testInput)).toEqual(expectedValue);
     });


### PR DESCRIPTION
This PR is a companion to #106, intended to improve test coverage of methods calling substr in preparation for replacing the code with a non-deprecated method.