### PR TITLE
Rename Fedora data classes for clarity.

### DIFF
--- a/api/src/models/FedoraDataCollection.test.ts
+++ b/api/src/models/FedoraDataCollection.test.ts
@@ -1,15 +1,15 @@
-import FedoraData from "./FedoraData";
+import FedoraDataCollection from "./FedoraDataCollection";
 
 let fedoraData;
 beforeEach(() => {
-    fedoraData = FedoraData.build("foo:123");
+    fedoraData = FedoraDataCollection.build("foo:123");
 });
 
-describe("FedoraData", () => {
+describe("FedoraDataCollection", () => {
     describe("addParent", () => {
         it("adds a parent", () => {
             expect(fedoraData.parents).toEqual([]);
-            const parent = FedoraData.build("parent:123");
+            const parent = FedoraDataCollection.build("parent:123");
             fedoraData.addParent(parent);
             expect(fedoraData.parents).toEqual([parent]);
         });

--- a/api/src/models/FedoraDataCollection.ts
+++ b/api/src/models/FedoraDataCollection.ts
@@ -9,12 +9,12 @@ interface TreeNode {
     parents: Array<TreeNode>;
 }
 
-class FedoraData {
+class FedoraDataCollection {
     public metadata: Record<string, Array<string>>;
     public pid: string;
     public fedoraDetails: Record<string, Array<string>>;
     public fedoraDatastreams: Array<string>;
-    public parents: Array<FedoraData> = [];
+    public parents: Array<FedoraDataCollection> = [];
     public datastreamDetails: FedoraDatastreamDetails;
 
     constructor(
@@ -41,8 +41,8 @@ class FedoraData {
         fedora: Fedora = null,
         extractor: MetadataExtractor = null,
         tika: TikaExtractor = null
-    ): FedoraData {
-        return new FedoraData(
+    ): FedoraDataCollection {
+        return new FedoraDataCollection(
             pid,
             metadata,
             fedoraDetails,
@@ -53,18 +53,18 @@ class FedoraData {
         );
     }
 
-    addParent(parent: FedoraData): void {
+    addParent(parent: FedoraDataCollection): void {
         this.parents.push(parent);
     }
 
-    getAllHierarchyTops(): Array<FedoraData> {
+    getAllHierarchyTops(): Array<FedoraDataCollection> {
         // If we have no parents, we ARE the top:
         if (this.parents.length === 0) {
             return [this];
         }
 
         // Otherwise, let's collect data from our parents:
-        const tops: Array<FedoraData> = [];
+        const tops: Array<FedoraDataCollection> = [];
         for (const parent of this.parents) {
             for (const top of parent.getAllHierarchyTops()) {
                 if (!tops.includes(top)) {
@@ -177,4 +177,4 @@ class FedoraData {
     }
 }
 
-export default FedoraData;
+export default FedoraDataCollection;

--- a/api/src/models/FedoraDatastreamDetails.ts
+++ b/api/src/models/FedoraDatastreamDetails.ts
@@ -1,5 +1,5 @@
 import Fedora from "../services/Fedora";
-import FedoraData from "./FedoraData";
+import FedoraDataCollection from "./FedoraDataCollection";
 import MetadataExtractor from "../services/MetadataExtractor";
 import TikaExtractor from "../services/TikaExtractor";
 
@@ -8,7 +8,7 @@ interface LicenseData {
 }
 
 class FedoraDatastreamDetails {
-    protected data: FedoraData;
+    protected data: FedoraDataCollection;
     protected fedora: Fedora;
     protected extractor: MetadataExtractor;
     protected tika: TikaExtractor;
@@ -18,7 +18,7 @@ class FedoraDatastreamDetails {
     protected fitsData: Record<string, Array<string>>;
     protected fullText: Record<string, Array<string>>;
 
-    constructor(data: FedoraData, fedora: Fedora, extractor: MetadataExtractor, tika: TikaExtractor) {
+    constructor(data: FedoraDataCollection, fedora: Fedora, extractor: MetadataExtractor, tika: TikaExtractor) {
         this.data = data;
         this.fedora = fedora;
         this.extractor = extractor;

--- a/api/src/routes/edit.test.ts
+++ b/api/src/routes/edit.test.ts
@@ -5,9 +5,9 @@ import edit from "./edit";
 import Config from "../models/Config";
 import DatastreamManager from "../services/DatastreamManager";
 import FedoraObjectFactory from "../services/FedoraObjectFactory";
-import HierarchyCollector from "../services/HierarchyCollector";
+import FedoraDataCollector from "../services/FedoraDataCollector";
 import * as Database from "../services/Database";
-import FedoraData from "../models/FedoraData";
+import FedoraDataCollection from "../models/FedoraDataCollection";
 import { FedoraObject } from "../models/FedoraObject";
 
 jest.mock("../models/Config");
@@ -60,9 +60,9 @@ describe("edit", () => {
             expect(response.text).toEqual("Missing state parameter.");
         });
         it("will fail if parent does not have collection model", async () => {
-            const mockData = FedoraData.build("pid:123");
-            const collector = HierarchyCollector.getInstance();
-            const dataSpy = jest.spyOn(collector, "getFedoraData").mockResolvedValue(mockData);
+            const mockData = FedoraDataCollection.build("pid:123");
+            const collector = FedoraDataCollector.getInstance();
+            const dataSpy = jest.spyOn(collector, "getSingleObject").mockResolvedValue(mockData);
             const response = await request(app)
                 .post("/edit/object/new")
                 .send({ model: "vudl-system:foo", title: "bar", state: "Active", parent: "pid:123" })
@@ -73,7 +73,7 @@ describe("edit", () => {
             expect(dataSpy).toHaveBeenCalledWith("pid:123");
         });
         it("will succeed if parent has collection model", async () => {
-            const mockData = FedoraData.build("pid:123");
+            const mockData = FedoraDataCollection.build("pid:123");
             mockData.fedoraDetails = {
                 hasModel: [
                     "http://localhost:8080/rest/vudl-system:FolderModel",
@@ -81,8 +81,8 @@ describe("edit", () => {
                     "http://localhost:8080/rest/vudl-system:CollectionModel",
                 ],
             };
-            const collector = HierarchyCollector.getInstance();
-            const dataSpy = jest.spyOn(collector, "getFedoraData").mockResolvedValue(mockData);
+            const collector = FedoraDataCollector.getInstance();
+            const dataSpy = jest.spyOn(collector, "getSingleObject").mockResolvedValue(mockData);
             const factory = FedoraObjectFactory.getInstance();
             const newObject = FedoraObject.build("child:123");
             const factorySpy = jest.spyOn(factory, "build").mockResolvedValue(newObject);

--- a/api/src/routes/edit.test.ts
+++ b/api/src/routes/edit.test.ts
@@ -62,7 +62,7 @@ describe("edit", () => {
         it("will fail if parent does not have collection model", async () => {
             const mockData = FedoraDataCollection.build("pid:123");
             const collector = FedoraDataCollector.getInstance();
-            const dataSpy = jest.spyOn(collector, "getSingleObject").mockResolvedValue(mockData);
+            const dataSpy = jest.spyOn(collector, "getObjectData").mockResolvedValue(mockData);
             const response = await request(app)
                 .post("/edit/object/new")
                 .send({ model: "vudl-system:foo", title: "bar", state: "Active", parent: "pid:123" })
@@ -82,7 +82,7 @@ describe("edit", () => {
                 ],
             };
             const collector = FedoraDataCollector.getInstance();
-            const dataSpy = jest.spyOn(collector, "getSingleObject").mockResolvedValue(mockData);
+            const dataSpy = jest.spyOn(collector, "getObjectData").mockResolvedValue(mockData);
             const factory = FedoraObjectFactory.getInstance();
             const newObject = FedoraObject.build("child:123");
             const factorySpy = jest.spyOn(factory, "build").mockResolvedValue(newObject);

--- a/api/src/routes/edit.ts
+++ b/api/src/routes/edit.ts
@@ -6,13 +6,13 @@ import FedoraCatalog from "../services/FedoraCatalog";
 import { FedoraObject } from "../models/FedoraObject";
 import DatastreamManager from "../services/DatastreamManager";
 import FedoraObjectFactory from "../services/FedoraObjectFactory";
-import HierarchyCollector from "../services/HierarchyCollector";
+import FedoraDataCollector from "../services/FedoraDataCollector";
 import MetadataExtractor from "../services/MetadataExtractor";
 import { requireToken } from "./auth";
 import { datastreamSanitizer, pidSanitizer } from "./sanitize";
 import * as formidable from "formidable";
 import Solr from "../services/Solr";
-import FedoraData from "../models/FedoraData";
+import FedoraDataCollection from "../models/FedoraDataCollection";
 const edit = express.Router();
 
 edit.get("/models", requireToken, function (req, res) {
@@ -58,10 +58,10 @@ edit.post("/object/new", requireToken, bodyParser.json(), async function (req, r
 
     // Validate parent PID, if set:
     if (parentPid !== null) {
-        const collector = HierarchyCollector.getInstance();
-        let parent: FedoraData;
+        const collector = FedoraDataCollector.getInstance();
+        let parent: FedoraDataCollection;
         try {
-            parent = await collector.getFedoraData(parentPid);
+            parent = await collector.getSingleObject(parentPid);
         } catch (e) {
             res.status(404).send("Error loading parent PID: " + parentPid);
             return;
@@ -123,7 +123,7 @@ function uploadFile(req, res, next) {
 
 edit.get("/object/modelsdatastreams/:pid", requireToken, pidSanitizer, async function (req, res) {
     try {
-        const data = await HierarchyCollector.getInstance().getFedoraData(req.params.pid);
+        const data = await FedoraDataCollector.getInstance().getSingleObject(req.params.pid);
         res.json({ models: data.models, datastreams: data.fedoraDatastreams });
     } catch (error) {
         console.error(error);
@@ -144,7 +144,7 @@ edit.get("/object/details/:pid", requireToken, pidSanitizer, async function (req
 
 edit.get("/object/parents/:pid", pidSanitizer, requireToken, async function (req, res) {
     try {
-        const fedoraData = await HierarchyCollector.getInstance().getHierarchy(req.params.pid);
+        const fedoraData = await FedoraDataCollector.getInstance().getHierarchy(req.params.pid);
         res.json(fedoraData.getParentTree());
     } catch (e) {
         console.error("Error retrieving breadcrumbs: " + e);

--- a/api/src/routes/edit.ts
+++ b/api/src/routes/edit.ts
@@ -61,7 +61,7 @@ edit.post("/object/new", requireToken, bodyParser.json(), async function (req, r
         const collector = FedoraDataCollector.getInstance();
         let parent: FedoraDataCollection;
         try {
-            parent = await collector.getSingleObject(parentPid);
+            parent = await collector.getObjectData(parentPid);
         } catch (e) {
             res.status(404).send("Error loading parent PID: " + parentPid);
             return;
@@ -123,7 +123,7 @@ function uploadFile(req, res, next) {
 
 edit.get("/object/modelsdatastreams/:pid", requireToken, pidSanitizer, async function (req, res) {
     try {
-        const data = await FedoraDataCollector.getInstance().getSingleObject(req.params.pid);
+        const data = await FedoraDataCollector.getInstance().getObjectData(req.params.pid);
         res.json({ models: data.models, datastreams: data.fedoraDatastreams });
     } catch (error) {
         console.error(error);

--- a/api/src/services/FedoraDataCollector.test.ts
+++ b/api/src/services/FedoraDataCollector.test.ts
@@ -1,11 +1,11 @@
 import Fedora from "./Fedora";
-import HierarchyCollector from "./HierarchyCollector";
+import FedoraDataCollector from "./FedoraDataCollector";
 import MetadataExtractor from "./MetadataExtractor";
 
-describe("HierarchyCollector", () => {
+describe("FedoraDataCollector", () => {
     let collector;
     beforeEach(() => {
-        collector = HierarchyCollector.getInstance();
+        collector = FedoraDataCollector.getInstance();
     });
 
     afterEach(() => {

--- a/api/src/services/FedoraDataCollector.ts
+++ b/api/src/services/FedoraDataCollector.ts
@@ -31,7 +31,7 @@ class FedoraDataCollector {
         return FedoraDataCollector.instance;
     }
 
-    async getSingleObject(pid: string): Promise<FedoraDataCollection> {
+    async getObjectData(pid: string): Promise<FedoraDataCollection> {
         // Use Fedora to get data
         const DCPromise = this.fedora.getDublinCore(pid);
         const RDFPromise = this.fedora.getRdf(pid, false);
@@ -49,7 +49,7 @@ class FedoraDataCollector {
     }
 
     async getHierarchy(pid: string): Promise<FedoraDataCollection> {
-        const result = await this.getSingleObject(pid);
+        const result = await this.getObjectData(pid);
         // Create promises to retrieve parents asynchronously...
         const promises = (result.fedoraDetails.isMemberOf ?? []).map(async (resource) => {
             const parentPid = resource.split("/").pop();

--- a/api/src/services/SolrIndexer.test.ts
+++ b/api/src/services/SolrIndexer.test.ts
@@ -1,7 +1,7 @@
 import Config from "../models/Config";
 import Fedora from "./Fedora";
-import FedoraData from "../models/FedoraData";
-import HierarchyCollector from "./HierarchyCollector";
+import FedoraDataCollection from "../models/FedoraDataCollection";
+import FedoraDataCollector from "./FedoraDataCollector";
 import { NeedleResponse } from "./interfaces";
 import SolrIndexer from "./SolrIndexer";
 import TikaExtractor from "./TikaExtractor";
@@ -25,8 +25,8 @@ describe("SolrIndexer", () => {
     it("returns reasonable results in response to almost-empty input", async () => {
         const changeSpy = jest.spyOn(indexer, "getChangeTrackerDetails").mockResolvedValue({});
         const pid = "test:123";
-        const collector = HierarchyCollector.getInstance();
-        const record = FedoraData.build(pid);
+        const collector = FedoraDataCollector.getInstance();
+        const record = FedoraDataCollection.build(pid);
         const getHierarchySpy = jest.spyOn(collector, "getHierarchy").mockResolvedValue(record);
         const result = await indexer.getFields(pid);
         expect(result).toEqual({
@@ -59,22 +59,22 @@ describe("SolrIndexer", () => {
         const pid = "test:123";
         const parentPid = "test:122";
         const grandparentPid = "test:121";
-        const collector = HierarchyCollector.getInstance();
+        const collector = FedoraDataCollector.getInstance();
         const recordDetails = {
             hasModel: ["vudl-system:CoreModel", "vudl-system:DataModel", "vudl-system:ImageData"],
             sequence: [parentPid + "#1"],
         };
-        const record = FedoraData.build(pid, { "dc:title": ["page"] }, recordDetails);
+        const record = FedoraDataCollection.build(pid, { "dc:title": ["page"] }, recordDetails);
         const parentRecordDetails = {
             hasModel: ["vudl-system:CoreModel", "vudl-system:CollectionModel", "vudl-system:ListCollection"],
             sortOn: ["custom"],
         };
-        const parentRecord = FedoraData.build(parentPid, { "dc:title": ["page list"] }, parentRecordDetails);
+        const parentRecord = FedoraDataCollection.build(parentPid, { "dc:title": ["page list"] }, parentRecordDetails);
         record.addParent(parentRecord);
         const grandparentRecordDetails = {
             hasModel: ["vudl-system:CoreModel", "vudl-system:CollectionModel", "vudl-system:ResourceCollection"],
         };
-        const grandparentRecord = FedoraData.build(
+        const grandparentRecord = FedoraDataCollection.build(
             grandparentPid,
             { "dc:title": ["test record"] },
             grandparentRecordDetails
@@ -164,8 +164,8 @@ describe("SolrIndexer", () => {
         const metadata = {
             "dc:title": [title, altTitle],
         };
-        const collector = HierarchyCollector.getInstance();
-        const record = FedoraData.build(pid, metadata);
+        const collector = FedoraDataCollector.getInstance();
+        const record = FedoraDataCollection.build(pid, metadata);
         const getHierarchySpy = jest.spyOn(collector, "getHierarchy").mockResolvedValue(record);
         const result = await indexer.getFields(pid);
         expect(result).toEqual({
@@ -219,8 +219,8 @@ describe("SolrIndexer", () => {
             "dc:relation": ["Relation"],
             "dc:date": ["1979-12-06"],
         };
-        const collector = HierarchyCollector.getInstance();
-        const record = FedoraData.build(pid, metadata);
+        const collector = FedoraDataCollector.getInstance();
+        const record = FedoraDataCollection.build(pid, metadata);
         const getHierarchySpy = jest.spyOn(collector, "getHierarchy").mockResolvedValue(record);
         const result = await indexer.getFields(pid);
         expect(result).toEqual({
@@ -300,8 +300,8 @@ describe("SolrIndexer", () => {
     it("processes agent data correctly", async () => {
         const changeSpy = jest.spyOn(indexer, "getChangeTrackerDetails").mockResolvedValue({});
         const pid = "test:123";
-        const collector = HierarchyCollector.getInstance();
-        const record = FedoraData.build(pid, {}, {}, ["AGENTS"]);
+        const collector = FedoraDataCollector.getInstance();
+        const record = FedoraDataCollection.build(pid, {}, {}, ["AGENTS"]);
         const getHierarchySpy = jest.spyOn(collector, "getHierarchy").mockResolvedValue(record);
         const fedora = Fedora.getInstance();
         const agentXml = `<METS:metsHdr xmlns:METS="http://www.loc.gov/METS/" CREATEDATE="2012-08-16T02:28:47.698Z" LASTMODDATE="2012-08-17T20:25:54.802Z" RECORDSTATUS="PUBLISHED">
@@ -348,8 +348,8 @@ describe("SolrIndexer", () => {
     it("processes license data correctly", async () => {
         const changeSpy = jest.spyOn(indexer, "getChangeTrackerDetails").mockResolvedValue({});
         const pid = "test:123";
-        const collector = HierarchyCollector.getInstance();
-        const record = FedoraData.build(pid, {}, {}, ["LICENSE"]);
+        const collector = FedoraDataCollector.getInstance();
+        const record = FedoraDataCollection.build(pid, {}, {}, ["LICENSE"]);
         const getHierarchySpy = jest.spyOn(collector, "getHierarchy").mockResolvedValue(record);
         const fedora = Fedora.getInstance();
         const licenseXml = `<METS:rightsMD xmlns:METS="http://www.loc.gov/METS/" ID="0">
@@ -388,8 +388,8 @@ describe("SolrIndexer", () => {
     it("processes FITS data correctly", async () => {
         const changeSpy = jest.spyOn(indexer, "getChangeTrackerDetails").mockResolvedValue({});
         const pid = "test:123";
-        const collector = HierarchyCollector.getInstance();
-        const record = FedoraData.build(pid, {}, {}, ["MASTER-MD"]);
+        const collector = FedoraDataCollector.getInstance();
+        const record = FedoraDataCollection.build(pid, {}, {}, ["MASTER-MD"]);
         const getHierarchySpy = jest.spyOn(collector, "getHierarchy").mockResolvedValue(record);
         const fedora = Fedora.getInstance();
         const fitsXml = `<?xml version="1.0" encoding="UTF-8"?>
@@ -477,8 +477,8 @@ describe("SolrIndexer", () => {
     it("processes thumbnail data correctly", async () => {
         const changeSpy = jest.spyOn(indexer, "getChangeTrackerDetails").mockResolvedValue({});
         const pid = "test:123";
-        const collector = HierarchyCollector.getInstance();
-        const record = FedoraData.build(pid, {}, {}, ["THUMBNAIL"]);
+        const collector = FedoraDataCollector.getInstance();
+        const record = FedoraDataCollection.build(pid, {}, {}, ["THUMBNAIL"]);
         const getHierarchySpy = jest.spyOn(collector, "getHierarchy").mockResolvedValue(record);
         const fedora = Fedora.getInstance();
         const agentXml = `<rdf:RDF
@@ -539,8 +539,11 @@ describe("SolrIndexer", () => {
     it("processes full text data correctly", async () => {
         const changeSpy = jest.spyOn(indexer, "getChangeTrackerDetails").mockResolvedValue({});
         const pid = "test:123";
-        const collector = HierarchyCollector.getInstance();
-        const record = FedoraData.build(pid, {}, { hasModel: ["vudl-system:PDFData"] }, ["MASTER", "OCR-DIRTY"]);
+        const collector = FedoraDataCollector.getInstance();
+        const record = FedoraDataCollection.build(pid, {}, { hasModel: ["vudl-system:PDFData"] }, [
+            "MASTER",
+            "OCR-DIRTY",
+        ]);
         const getHierarchySpy = jest.spyOn(collector, "getHierarchy").mockResolvedValue(record);
         const fedora = Fedora.getInstance();
         const getStreamSpy = jest.spyOn(fedora, "getDatastreamAsString").mockResolvedValue("dirty OCR");

--- a/api/src/services/SolrIndexer.ts
+++ b/api/src/services/SolrIndexer.ts
@@ -1,7 +1,7 @@
 import Config from "../models/Config";
 import DateSanitizer from "./DateSanitizer";
-import FedoraData from "../models/FedoraData";
-import HierarchyCollector from "./HierarchyCollector";
+import FedoraDataCollection from "../models/FedoraDataCollection";
+import FedoraDataCollector from "./FedoraDataCollector";
 import http = require("needle");
 import { NeedleResponse } from "./interfaces";
 import Solr from "./Solr";
@@ -13,11 +13,11 @@ interface SolrFields {
 class SolrIndexer {
     private static instance: SolrIndexer;
     config: Config;
-    hierarchyCollector: HierarchyCollector;
+    fedoraDataCollector: FedoraDataCollector;
     solr: Solr;
 
-    constructor(hierarchyCollector: HierarchyCollector, solr: Solr, config: Config) {
-        this.hierarchyCollector = hierarchyCollector;
+    constructor(fedoraDataCollector: FedoraDataCollector, solr: Solr, config: Config) {
+        this.fedoraDataCollector = fedoraDataCollector;
         this.config = config;
         this.solr = solr;
     }
@@ -25,7 +25,7 @@ class SolrIndexer {
     public static getInstance(): SolrIndexer {
         if (!SolrIndexer.instance) {
             SolrIndexer.instance = new SolrIndexer(
-                HierarchyCollector.getInstance(),
+                FedoraDataCollector.getInstance(),
                 Solr.getInstance(),
                 Config.getInstance()
             );
@@ -71,14 +71,14 @@ class SolrIndexer {
         // Empty out Fedora cache data to be sure we get the latest
         // information while indexing.
         // TODO: review datastream caching logic; do we need it? Is there a better way?
-        this.hierarchyCollector.fedora.clearCache(pid);
+        this.fedoraDataCollector.fedora.clearCache(pid);
         const fedoraFields = await this.getFields(pid);
         return await this.solr.indexRecord(this.config.solrCore, fedoraFields);
     }
 
     async getFields(pid: string): Promise<SolrFields> {
         // Collect hierarchy data
-        const fedoraData = await this.hierarchyCollector.getHierarchy(pid);
+        const fedoraData = await this.fedoraDataCollector.getHierarchy(pid);
 
         // Start with basic data:
         const fields: SolrFields = {
@@ -110,8 +110,8 @@ class SolrIndexer {
 
         // Process parent data (note that hierarchyParents makes some special exceptions for VuFind;
         // fedoraParents exactly maintains the hierarchy as represented in Fedora):
-        const hierarchyParents: Array<FedoraData> = [];
-        const fedoraParents: Array<FedoraData> = [];
+        const hierarchyParents: Array<FedoraDataCollection> = [];
+        const fedoraParents: Array<FedoraDataCollection> = [];
         const hierarchySequences: Array<string> = [];
         for (const parent of fedoraData.parents) {
             // Fedora parents should directly reflect the repository without any
@@ -132,7 +132,7 @@ class SolrIndexer {
                 hierarchySequences.push(this.padNumber(sequenceIndex[parent.pid] ?? 0));
             }
         }
-        const hierarchyTops: Array<FedoraData> = fedoraData.getAllHierarchyTops();
+        const hierarchyTops: Array<FedoraDataCollection> = fedoraData.getAllHierarchyTops();
         if (hierarchyTops.length > 0) {
             fields.hierarchy_top_id = [];
             fields.hierarchy_top_title = [];
@@ -174,7 +174,7 @@ class SolrIndexer {
             // to look them up manually in Fedora. Perhaps this can be optimized or
             // simplified somehow...
             const titlePromises = ((fields.hierarchy_parent_id ?? []) as Array<string>).map(async (id) => {
-                const currentObject = await this.hierarchyCollector.getFedoraData(id);
+                const currentObject = await this.fedoraDataCollector.getSingleObject(id);
                 return currentObject.title;
             });
             fields.hierarchy_parent_title = await Promise.all(titlePromises);

--- a/api/src/services/SolrIndexer.ts
+++ b/api/src/services/SolrIndexer.ts
@@ -174,7 +174,7 @@ class SolrIndexer {
             // to look them up manually in Fedora. Perhaps this can be optimized or
             // simplified somehow...
             const titlePromises = ((fields.hierarchy_parent_id ?? []) as Array<string>).map(async (id) => {
-                const currentObject = await this.fedoraDataCollector.getSingleObject(id);
+                const currentObject = await this.fedoraDataCollector.getObjectData(id);
                 return currentObject.title;
             });
             fields.hierarchy_parent_title = await Promise.all(titlePromises);


### PR DESCRIPTION
This PR renames the FedoraData model to FedoraDataCollection (to better differentiate it from the FedoraObject model, which represents a single object in Fedora as opposed to a collection of data pulled from Fedora) and renames the HierarchyCollector service to FedoraDataCollector (to correlate it with FedoraDataCollection, and to reflect the fact that it doesn't deal exclusively in hierarchies).

I believe this significantly improves the clarity of the naming in the backend code.