### PR TITLE
Remove Fedora cache logic.

### DIFF
--- a/api/src/services/FedoraDataCollector.test.ts
+++ b/api/src/services/FedoraDataCollector.test.ts
@@ -48,8 +48,8 @@ describe("FedoraDataCollector", () => {
         expect(dublinCoreSpy).toHaveBeenNthCalledWith(1, pid);
         expect(dublinCoreSpy).toHaveBeenNthCalledWith(2, parentPid);
         expect(rdfSpy).toHaveBeenCalledTimes(2);
-        expect(rdfSpy).toHaveBeenNthCalledWith(1, pid, false);
-        expect(rdfSpy).toHaveBeenNthCalledWith(2, parentPid, false);
+        expect(rdfSpy).toHaveBeenNthCalledWith(1, pid);
+        expect(rdfSpy).toHaveBeenNthCalledWith(2, parentPid);
         expect(extraMetadataSpy).toHaveBeenCalledTimes(2);
         expect(extraMetadataSpy).toHaveBeenNthCalledWith(1, dc1);
         expect(extraMetadataSpy).toHaveBeenNthCalledWith(2, dc2);

--- a/api/src/services/FedoraDataCollector.ts
+++ b/api/src/services/FedoraDataCollector.ts
@@ -34,7 +34,7 @@ class FedoraDataCollector {
     async getObjectData(pid: string): Promise<FedoraDataCollection> {
         // Use Fedora to get data
         const DCPromise = this.fedora.getDublinCore(pid);
-        const RDFPromise = this.fedora.getRdf(pid, false);
+        const RDFPromise = this.fedora.getRdf(pid);
         const [DC, RDF] = await Promise.all([DCPromise, RDFPromise]);
 
         return new FedoraDataCollection(

--- a/api/src/services/SolrIndexer.ts
+++ b/api/src/services/SolrIndexer.ts
@@ -68,10 +68,6 @@ class SolrIndexer {
     }
 
     async indexPid(pid: string): Promise<NeedleResponse> {
-        // Empty out Fedora cache data to be sure we get the latest
-        // information while indexing.
-        // TODO: review datastream caching logic; do we need it? Is there a better way?
-        this.fedoraDataCollector.fedora.clearCache(pid);
         const fedoraFields = await this.getFields(pid);
         return await this.solr.indexRecord(this.config.solrCore, fedoraFields);
     }


### PR DESCRIPTION
I believe that internal Fedora caching was a premature optimization likely to cause more problems than it solved. This PR removes the feature. If we need caching, I think we should do it at a higher level in a more targeted way.