### PR TITLE
Include dc:identifier in initial object metadata.

### DIFF
--- a/api/src/services/Fedora.test.ts
+++ b/api/src/services/Fedora.test.ts
@@ -21,6 +21,10 @@ describe("Fedora", () => {
         fedora = Fedora.getInstance();
     });
 
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
     describe("addRelationship", () => {
         beforeEach(() => {
             requestSpy = jest.spyOn(fedora, "_request").mockResolvedValue({ statusCode: 204 });
@@ -66,6 +70,36 @@ describe("Fedora", () => {
         it("will delete a datastream tombstone", async () => {
             fedora.deleteDatastreamTombstone(pid, datastream, {});
             expect(requestSpy).toHaveBeenCalledWith("delete", pid + "/" + datastream + "/fcr:tombstone", null, {});
+        });
+    });
+
+    describe("createContainer", () => {
+        beforeEach(() => {
+            requestSpy = jest.spyOn(fedora, "_request").mockResolvedValue({ statusCode: 201 });
+        });
+
+        it("generates appropriate metadata", async () => {
+            const addDatastreamSpy = jest.spyOn(fedora, "addDatastream").mockResolvedValue({});
+            await fedora.createContainer("foo:123", "label", "A");
+            const expectedHeaders = { headers: { "Content-Type": "text/turtle" } };
+            const expectedTurtle = `<> <http://purl.org/dc/terms/title> "label";
+    <info:fedora/fedora-system:def/model#label> "label";
+    <info:fedora/fedora-system:def/model#state> "A";
+    <info:fedora/fedora-system:def/model#ownerId> "diglibEditor".
+`;
+            expect(requestSpy).toHaveBeenCalledTimes(1);
+            expect(requestSpy).toHaveBeenCalledWith("put", "/foo:123", expectedTurtle, expectedHeaders);
+            expect(addDatastreamSpy).toHaveBeenCalledTimes(1);
+            const expectedParams = {
+                mimeType: "text/xml",
+                logMessage: "Create initial Dublin Core record",
+            };
+            const expectedXml = `<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <dc:identifier>foo:123</dc:identifier>
+  <dc:title>label</dc:title>
+</oai_dc:dc>
+`;
+            expect(addDatastreamSpy).toHaveBeenCalledWith("foo:123", "DC", expectedParams, expectedXml, [201]);
         });
     });
 });

--- a/api/src/services/Fedora.ts
+++ b/api/src/services/Fedora.ts
@@ -376,6 +376,9 @@ export class Fedora {
         const xml =
             '<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">' +
             "\n" +
+            "  <dc:identifier>" +
+            xmlescape(pid) +
+            "</dc:identifier>\n" +
             "  <dc:title>" +
             xmlescape(label) +
             "</dc:title>\n" +


### PR DESCRIPTION
While testing, I noticed an oversight: the code was not initializing DC metadata with the appropriate identifier value. This PR corrects the problem.