### PR TITLE
Improved routes

### DIFF
--- a/api/src/routes/edit.ts
+++ b/api/src/routes/edit.ts
@@ -120,8 +120,9 @@ function uploadFile(req, res, next) {
         }
     });
 }
+edit.post("/object/:pid", requireToken, pidSanitizer, uploadFile);
 
-edit.get("/object/modelsdatastreams/:pid", requireToken, pidSanitizer, async function (req, res) {
+edit.get("/object/:pid/modelsdatastreams", requireToken, pidSanitizer, async function (req, res) {
     try {
         const data = await FedoraDataCollector.getInstance().getObjectData(req.params.pid);
         res.json({ models: data.models, datastreams: data.fedoraDatastreams });
@@ -130,10 +131,9 @@ edit.get("/object/modelsdatastreams/:pid", requireToken, pidSanitizer, async fun
         res.status(500).send(error.message);
     }
 });
-edit.post("/object/:pid", requireToken, pidSanitizer, uploadFile);
-edit.get("/object/children", requireToken, getChildren);
-edit.get("/object/children/:pid", requireToken, pidSanitizer, getChildren);
-edit.get("/object/details/:pid", requireToken, pidSanitizer, async function (req, res) {
+edit.get("/treeTop", requireToken, getChildren);
+edit.get("/object/:pid/children", requireToken, pidSanitizer, getChildren);
+edit.get("/object/:pid/details", requireToken, pidSanitizer, async function (req, res) {
     const pid = req.params.pid;
     const obj = FedoraObject.build(pid);
     const sort = await obj.getSort();
@@ -142,7 +142,7 @@ edit.get("/object/details/:pid", requireToken, pidSanitizer, async function (req
     res.json({ pid, sort, metadata: extractedMetadata });
 });
 
-edit.get("/object/parents/:pid", pidSanitizer, requireToken, async function (req, res) {
+edit.get("/object/:pid/parents", pidSanitizer, requireToken, async function (req, res) {
     try {
         const fedoraData = await FedoraDataCollector.getInstance().getHierarchy(req.params.pid);
         res.json(fedoraData.getParentTree());

--- a/api/src/routes/edit.ts
+++ b/api/src/routes/edit.ts
@@ -130,7 +130,7 @@ edit.get("/object/:pid/modelsdatastreams", requireToken, pidSanitizer, async fun
         res.status(500).send(error.message);
     }
 });
-edit.get("/treeTop", requireToken, getChildren);
+edit.get("/topLevelObjects", requireToken, getChildren);
 edit.get("/object/:pid/children", requireToken, pidSanitizer, getChildren);
 edit.get("/object/:pid/details", requireToken, pidSanitizer, async function (req, res) {
     const pid = req.params.pid;

--- a/api/src/routes/edit.ts
+++ b/api/src/routes/edit.ts
@@ -101,7 +101,7 @@ async function getChildren(req, res) {
 }
 
 function uploadFile(req, res, next) {
-    const { pid } = req.params;
+    const { pid, stream } = req.params;
     const form = formidable({ multiples: true });
 
     form.parse(req, async (err, fields, files) => {
@@ -111,7 +111,6 @@ function uploadFile(req, res, next) {
         }
         try {
             const datastream = DatastreamManager.getInstance();
-            const { stream } = fields;
             const { filepath, mimetype } = files?.file;
             await datastream.uploadFile(pid, stream, filepath, mimetype);
             res.status(200).send("Upload success");
@@ -120,7 +119,7 @@ function uploadFile(req, res, next) {
         }
     });
 }
-edit.post("/object/:pid", requireToken, pidSanitizer, uploadFile);
+edit.post("/object/:pid/datastream/:stream", requireToken, datastreamSanitizer, uploadFile);
 
 edit.get("/object/:pid/modelsdatastreams", requireToken, pidSanitizer, async function (req, res) {
     try {

--- a/client/components/edit/Breadcrumbs.test.tsx
+++ b/client/components/edit/Breadcrumbs.test.tsx
@@ -32,7 +32,7 @@ describe("Breadcrumb", () => {
             </FetchContextProvider>
         );
         await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
-        expect(lastRequestUrl).toEqual("http://localhost:9000/api/edit/object/parents/foo%3A1234");
+        expect(lastRequestUrl).toEqual("http://localhost:9000/api/edit/object/foo%3A1234/parents");
         wrapper.update();
         expect(toJson(wrapper)).toMatchSnapshot();
     }

--- a/client/components/edit/Breadcrumbs.tsx
+++ b/client/components/edit/Breadcrumbs.tsx
@@ -1,7 +1,7 @@
 import styles from "./Breadcrumbs.module.css";
 import React, { useEffect, useState } from "react";
 import { useFetchContext } from "../../context/FetchContext";
-import { apiUrl } from "../../util/routes";
+import { getObjectParentsUrl } from "../../util/routes";
 import Link from "next/link";
 
 interface TreeNode {
@@ -77,7 +77,7 @@ const Breadcrumbs = ({ pid = "" }: BreadcrumbsProps): React.ReactElement => {
                 childLookups: {},
                 records: {},
             };
-            const url = apiUrl + "/edit/object/parents/" + encodeURIComponent(pid);
+            const url = getObjectParentsUrl(pid);
             try {
                 data = processBreadcrumbData(await fetchJSON(url));
             } catch (e) {

--- a/client/components/edit/ChildList.test.tsx
+++ b/client/components/edit/ChildList.test.tsx
@@ -31,7 +31,7 @@ describe("ChildList", () => {
             </FetchContextProvider>
         );
         await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
-        expect(lastRequestUrl).toEqual("http://localhost:9000/api/edit/treeTop");
+        expect(lastRequestUrl).toEqual("http://localhost:9000/api/edit/topLevelObjects");
         wrapper.update();
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/client/components/edit/ChildList.test.tsx
+++ b/client/components/edit/ChildList.test.tsx
@@ -31,7 +31,7 @@ describe("ChildList", () => {
             </FetchContextProvider>
         );
         await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
-        expect(lastRequestUrl).toEqual("http://localhost:9000/api/edit/object/children/");
+        expect(lastRequestUrl).toEqual("http://localhost:9000/api/edit/treeTop");
         wrapper.update();
         expect(toJson(wrapper)).toMatchSnapshot();
     });
@@ -44,7 +44,7 @@ describe("ChildList", () => {
             </FetchContextProvider>
         );
         await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
-        expect(lastRequestUrl).toEqual("http://localhost:9000/api/edit/object/children/foo:123");
+        expect(lastRequestUrl).toEqual("http://localhost:9000/api/edit/object/foo%3A123/children");
         wrapper.update();
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/client/components/edit/ChildList.tsx
+++ b/client/components/edit/ChildList.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useFetchContext } from "../../context/FetchContext";
-import { apiUrl } from "../../util/routes";
+import { getObjectChildrenUrl } from "../../util/routes";
 import Link from "next/link";
 
 interface ChildListProps {
@@ -25,7 +25,7 @@ const ChildList = ({ pid = "" }: ChildListProps): React.ReactElement => {
     useEffect(() => {
         async function loadData() {
             let data = [];
-            const url = apiUrl + "/edit/object/children/" + pid;
+            const url = getObjectChildrenUrl(pid);
             try {
                 data = await fetchJSON(url);
             } catch (e) {

--- a/client/components/edit/ObjectSummary.test.tsx
+++ b/client/components/edit/ObjectSummary.test.tsx
@@ -39,7 +39,7 @@ describe("ObjectSummary", () => {
             </FetchContextProvider>
         );
         await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
-        expect(lastRequestUrl).toEqual("http://localhost:9000/api/edit/object/details/foo%3A123");
+        expect(lastRequestUrl).toEqual("http://localhost:9000/api/edit/object/foo%3A123/details");
         wrapper.update();
         expect(toJson(wrapper)).toMatchSnapshot();
     });
@@ -55,7 +55,7 @@ describe("ObjectSummary", () => {
             </FetchContextProvider>
         );
         await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
-        expect(lastRequestUrl).toEqual("http://localhost:9000/api/edit/object/details/foo%3A123");
+        expect(lastRequestUrl).toEqual("http://localhost:9000/api/edit/object/foo%3A123/details");
         wrapper.update();
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/client/components/edit/ObjectSummary.tsx
+++ b/client/components/edit/ObjectSummary.tsx
@@ -2,7 +2,7 @@ import styles from "./ObjectSummary.module.css";
 import React, { useEffect, useState } from "react";
 import HtmlReactParser from "html-react-parser";
 import { useFetchContext } from "../../context/FetchContext";
-import { apiUrl } from "../../util/routes";
+import { getObjectDetailsUrl } from "../../util/routes";
 
 interface ObjectSummaryProps {
     pid: string;
@@ -22,7 +22,7 @@ const ObjectSummary = ({ pid = "" }: ObjectSummaryProps): React.ReactElement => 
     useEffect(() => {
         async function loadData() {
             let data = [];
-            const url = apiUrl + "/edit/object/details/" + encodeURIComponent(pid);
+            const url = getObjectDetailsUrl(pid);
             try {
                 data = await fetchJSON(url);
             } catch (e) {

--- a/client/hooks/useDatastreamOperation.test.ts
+++ b/client/hooks/useDatastreamOperation.test.ts
@@ -67,7 +67,7 @@ describe("useDatastreamOperation", () => {
 
 
             expect(fetchValues.action.fetchText).toHaveBeenCalledWith(
-                expect.stringContaining(editorValues.state.currentPid),
+                "http://localhost:9000/api/edit/object/vudl%3A123",
                 expect.objectContaining({
                     method: "POST",
                     body: expect.any(FormData),
@@ -119,7 +119,7 @@ describe("useDatastreamOperation", () => {
             await deleteDatastream()
 
             expect(fetchValues.action.fetchText).toHaveBeenCalledWith(
-                expect.stringContaining(editorValues.state.currentPid),
+                "http://localhost:9000/api/edit/object/vudl%3A123/datastream/THUMBNAIL",
                 expect.objectContaining({
                     method: "DELETE",
                 })
@@ -141,7 +141,7 @@ describe("useDatastreamOperation", () => {
             await deleteDatastream()
 
             expect(fetchValues.action.fetchText).toHaveBeenCalledWith(
-                expect.stringContaining(editorValues.state.currentPid),
+                "http://localhost:9000/api/edit/object/vudl%3A123/datastream/THUMBNAIL",
                 expect.objectContaining({
                     method: "DELETE",
                 })
@@ -220,7 +220,7 @@ describe("useDatastreamOperation", () => {
             await downloadDatastream("test1");
 
             expect(fetchValues.action.fetchBlob).toHaveBeenCalledWith(
-                expect.stringContaining(editorValues.state.currentPid)
+                "http://localhost:9000/api/edit/object/vudl%3A123/datastream/test1/download"
             );
 
             expect(editorValues.action.setSnackbarState).toHaveBeenCalledWith(
@@ -241,7 +241,7 @@ describe("useDatastreamOperation", () => {
             await downloadDatastream("test1");
 
             expect(fetchValues.action.fetchBlob).toHaveBeenCalledWith(
-                expect.stringContaining(editorValues.state.currentPid)
+                "http://localhost:9000/api/edit/object/vudl%3A123/datastream/test1/download"
             );
 
             expect(editorValues.action.setSnackbarState).toHaveBeenCalledWith(
@@ -260,7 +260,7 @@ describe("useDatastreamOperation", () => {
             await downloadDatastream("test1");
 
             expect(fetchValues.action.fetchBlob).toHaveBeenCalledWith(
-                expect.stringContaining(editorValues.state.currentPid)
+                "http://localhost:9000/api/edit/object/vudl%3A123/datastream/test1/download"
             );
 
             expect(editorValues.action.setSnackbarState).toHaveBeenCalledWith(

--- a/client/hooks/useDatastreamOperation.test.ts
+++ b/client/hooks/useDatastreamOperation.test.ts
@@ -1,7 +1,4 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
-import { UploadFile } from "@mui/icons-material";
-import { renderHook, act } from "@testing-library/react-hooks";
-import { deleteObjectDatastreamUrl, downloadObjectDatastreamUrl, postObjectDatastreamUrl } from "../util/routes";
 import useDatastreamOperation from "./useDatastreamOperation";
 
 const mockUseFetchContext = jest.fn();
@@ -67,7 +64,7 @@ describe("useDatastreamOperation", () => {
 
 
             expect(fetchValues.action.fetchText).toHaveBeenCalledWith(
-                "http://localhost:9000/api/edit/object/vudl%3A123",
+                "http://localhost:9000/api/edit/object/vudl%3A123/datastream/THUMBNAIL",
                 expect.objectContaining({
                     method: "POST",
                     body: expect.any(FormData),

--- a/client/hooks/useDatastreamOperation.ts
+++ b/client/hooks/useDatastreamOperation.ts
@@ -29,9 +29,8 @@ const useDatastreamOperation = () => {
                 throw new Error(`Illegal mime type: ${file.type}`);
             }
             const body = new FormData();
-            body.append("stream", activeDatastream);
             body.append("file", file);
-            const text = await fetchText(postObjectDatastreamUrl(currentPid), {
+            const text = await fetchText(postObjectDatastreamUrl(currentPid, activeDatastream), {
                 method: "POST",
                 body,
             });

--- a/client/util/routes.ts
+++ b/client/util/routes.ts
@@ -30,24 +30,36 @@ const getStatusUrl = (category: string, children: string): string => {
     return getJobUrl(category, children, "/status");
 };
 
+const getObjectChildrenUrl = (pid: string): string => {
+    return pid.length > 0 ? `${editObjectUrl}/${encodeURIComponent(pid)}/children` : `${apiUrl}/edit/treeTop`;
+}
+
+const getObjectDetailsUrl = (pid: string): string => {
+    return `${editObjectUrl}/${encodeURIComponent(pid)}/details`;
+}
+
 const getObjectModelsDatastreamsUrl = (pid: string): string => {
-    return `${editObjectUrl}/modelsdatastreams/${pid}`;
+    return `${editObjectUrl}/${encodeURIComponent(pid)}/modelsdatastreams`;
+}
+
+const getObjectParentsUrl = (pid: string): string => {
+    return `${editObjectUrl}/${encodeURIComponent(pid)}/parents`;
 }
 
 const postObjectDatastreamUrl = (pid: string): string => {
-    return `${editObjectUrl}/${pid}`;
+    return `${editObjectUrl}/${encodeURIComponent(pid)}`;
 }
 
 const deleteObjectDatastreamUrl = (pid: string, datastream: string): string => {
-    return `${editObjectUrl}/${pid}/datastream/${datastream}`;
+    return `${editObjectUrl}/${encodeURIComponent(pid)}/datastream/${encodeURIComponent(datastream)}`;
 }
 
 const downloadObjectDatastreamUrl = (pid: string, datastream: string) => {
-    return `${editObjectUrl}/${pid}/datastream/${datastream}/download`;
+    return `${editObjectUrl}/${encodeURIComponent(pid)}/datastream/${encodeURIComponent(datastream)}/download`;
 }
 
 const getObjectDatastreamMetadataUrl = (pid: string, datastream: string) => {
-    return `${editObjectUrl}/${pid}/datastream/${datastream}/metadata`;
+    return `${editObjectUrl}/${encodeURIComponent(pid)}/datastream/${encodeURIComponent(datastream)}/metadata`;
 }
 
 export {
@@ -65,7 +77,10 @@ export {
     getDerivUrl,
     getIngestUrl,
     getStatusUrl,
+    getObjectChildrenUrl,
+    getObjectDetailsUrl,
     getObjectModelsDatastreamsUrl,
+    getObjectParentsUrl,
     postObjectDatastreamUrl,
     deleteObjectDatastreamUrl,
     downloadObjectDatastreamUrl,

--- a/client/util/routes.ts
+++ b/client/util/routes.ts
@@ -35,7 +35,7 @@ const getPidActionUrl = (pid: string, action: string): string => {
 }
 
 const getObjectChildrenUrl = (pid: string): string => {
-    return pid.length > 0 ? getPidActionUrl(pid, "children") : `${apiUrl}/edit/treeTop`;
+    return pid.length > 0 ? getPidActionUrl(pid, "children") : `${apiUrl}/edit/topLevelObjects`;
 }
 
 const getObjectDetailsUrl = (pid: string): string => {

--- a/client/util/routes.ts
+++ b/client/util/routes.ts
@@ -30,36 +30,44 @@ const getStatusUrl = (category: string, children: string): string => {
     return getJobUrl(category, children, "/status");
 };
 
+const getPidActionUrl = (pid: string, action: string): string => {
+    return `${editObjectUrl}/${encodeURIComponent(pid)}/${action}`;
+}
+
 const getObjectChildrenUrl = (pid: string): string => {
-    return pid.length > 0 ? `${editObjectUrl}/${encodeURIComponent(pid)}/children` : `${apiUrl}/edit/treeTop`;
+    return pid.length > 0 ? getPidActionUrl(pid, "children") : `${apiUrl}/edit/treeTop`;
 }
 
 const getObjectDetailsUrl = (pid: string): string => {
-    return `${editObjectUrl}/${encodeURIComponent(pid)}/details`;
+    return getPidActionUrl(pid, "details");
 }
 
 const getObjectModelsDatastreamsUrl = (pid: string): string => {
-    return `${editObjectUrl}/${encodeURIComponent(pid)}/modelsdatastreams`;
+    return getPidActionUrl(pid, "modelsdatastreams");
 }
 
 const getObjectParentsUrl = (pid: string): string => {
-    return `${editObjectUrl}/${encodeURIComponent(pid)}/parents`;
+    return getPidActionUrl(pid, "parents");
+}
+
+const getDatastreamActionUrl = (pid: string, datastream: string, action = ""): string => {
+    return getPidActionUrl(pid, `datastream/${encodeURIComponent(datastream)}` + (action.length > 0 ? `/${action}` : ""));
 }
 
 const postObjectDatastreamUrl = (pid: string, datastream: string): string => {
-    return `${editObjectUrl}/${encodeURIComponent(pid)}/datastream/${encodeURIComponent(datastream)}`;
+    return getDatastreamActionUrl(pid, datastream);
 }
 
 const deleteObjectDatastreamUrl = (pid: string, datastream: string): string => {
-    return `${editObjectUrl}/${encodeURIComponent(pid)}/datastream/${encodeURIComponent(datastream)}`;
+    return getDatastreamActionUrl(pid, datastream);
 }
 
 const downloadObjectDatastreamUrl = (pid: string, datastream: string) => {
-    return `${editObjectUrl}/${encodeURIComponent(pid)}/datastream/${encodeURIComponent(datastream)}/download`;
+    return getDatastreamActionUrl(pid, datastream, "download");
 }
 
 const getObjectDatastreamMetadataUrl = (pid: string, datastream: string) => {
-    return `${editObjectUrl}/${encodeURIComponent(pid)}/datastream/${encodeURIComponent(datastream)}/metadata`;
+    return getDatastreamActionUrl(pid, datastream, "metadata");
 }
 
 export {

--- a/client/util/routes.ts
+++ b/client/util/routes.ts
@@ -46,8 +46,8 @@ const getObjectParentsUrl = (pid: string): string => {
     return `${editObjectUrl}/${encodeURIComponent(pid)}/parents`;
 }
 
-const postObjectDatastreamUrl = (pid: string): string => {
-    return `${editObjectUrl}/${encodeURIComponent(pid)}`;
+const postObjectDatastreamUrl = (pid: string, datastream: string): string => {
+    return `${editObjectUrl}/${encodeURIComponent(pid)}/datastream/${encodeURIComponent(datastream)}`;
 }
 
 const deleteObjectDatastreamUrl = (pid: string, datastream: string): string => {


### PR DESCRIPTION
This pull request standardizes the routes in the API for consistency:

- Object-related routes now take the form `/object/[pid]/action`
- The datastream upload route now uses `/object/[pid]/datastream/[stream]` for consistency with other stream-related routes
- The client route methods now use helper methods to enforce consistent application of patterns
- All pid and stream values are now properly URI encoded for safety