### PR TITLE
Add pagination control to child lists.

### DIFF
--- a/client/components/edit/ChildList.test.tsx
+++ b/client/components/edit/ChildList.test.tsx
@@ -6,19 +6,23 @@ import toJson from "enzyme-to-json";
 import ChildList from "./ChildList";
 import { FetchContextProvider } from "../../context/FetchContext";
 
+jest.mock("@mui/material/Pagination", () => () => "Pagination");
+
 describe("ChildList", () => {
     let props;
     let lastRequestUrl;
+    let response;
 
     beforeEach(() => {
         props = {};
+        response = { numFound: 1, start: 0, docs: [{ id: "foo:124", title: "hello" }] };
         global.fetch = jest.fn((url) => {
             lastRequestUrl = url;
             return {
                 ok: true,
                 status: 200,
                 json: async function () {
-                    return { docs: [{ id: "foo:124", title: "hello" }] };
+                    return response;
                 },
             };
         });
@@ -31,7 +35,37 @@ describe("ChildList", () => {
             </FetchContextProvider>
         );
         await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
-        expect(lastRequestUrl).toEqual("http://localhost:9000/api/edit/topLevelObjects");
+        expect(lastRequestUrl).toEqual("http://localhost:9000/api/edit/topLevelObjects?start=0&rows=10");
+        wrapper.update();
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it("displays a paginator when appropriate", async () => {
+        // with a page size of 10, the response will include 10 records, but numFound will show
+        // the full result set size
+        response = {
+            numFound: 10000,
+            start: 0,
+            docs: [
+                { id: "foo:124", title: "hello1" },
+                { id: "foo:125", title: "hello2" },
+                { id: "foo:126", title: "hello3" },
+                { id: "foo:127", title: "hello4" },
+                { id: "foo:128", title: "hello5" },
+                { id: "foo:129", title: "hello6" },
+                { id: "foo:130", title: "hello7" },
+                { id: "foo:131", title: "hello8" },
+                { id: "foo:132", title: "hello9" },
+                { id: "foo:133", title: "hello10" },
+            ],
+        };
+        const wrapper = mount(
+            <FetchContextProvider>
+                <ChildList {...props} />
+            </FetchContextProvider>
+        );
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+        expect(lastRequestUrl).toEqual("http://localhost:9000/api/edit/topLevelObjects?start=0&rows=10");
         wrapper.update();
         expect(toJson(wrapper)).toMatchSnapshot();
     });
@@ -44,7 +78,7 @@ describe("ChildList", () => {
             </FetchContextProvider>
         );
         await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
-        expect(lastRequestUrl).toEqual("http://localhost:9000/api/edit/object/foo%3A123/children");
+        expect(lastRequestUrl).toEqual("http://localhost:9000/api/edit/object/foo%3A123/children?start=0&rows=10");
         wrapper.update();
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/client/components/edit/ChildList.tsx
+++ b/client/components/edit/ChildList.tsx
@@ -2,9 +2,11 @@ import React, { useEffect, useState } from "react";
 import { useFetchContext } from "../../context/FetchContext";
 import { getObjectChildrenUrl } from "../../util/routes";
 import Link from "next/link";
+import Pagination from "@mui/material/Pagination";
 
 interface ChildListProps {
     pid: string;
+    pageSize: number;
 }
 interface Children {
     numFound: number;
@@ -12,7 +14,7 @@ interface Children {
     docs: Record<string, string>[];
 }
 
-const ChildList = ({ pid = "" }: ChildListProps): React.ReactElement => {
+const ChildList = ({ pid = "", pageSize = 10 }: ChildListProps): React.ReactElement => {
     const {
         action: { fetchJSON },
     } = useFetchContext();
@@ -21,11 +23,12 @@ const ChildList = ({ pid = "" }: ChildListProps): React.ReactElement => {
         start: 0,
         docs: [],
     });
+    const [page, setPage] = useState<number>(1);
 
     useEffect(() => {
         async function loadData() {
             let data = [];
-            const url = getObjectChildrenUrl(pid);
+            const url = getObjectChildrenUrl(pid, (page - 1) * pageSize, pageSize);
             try {
                 data = await fetchJSON(url);
             } catch (e) {
@@ -34,7 +37,7 @@ const ChildList = ({ pid = "" }: ChildListProps): React.ReactElement => {
             setChildren(data);
         }
         loadData();
-    }, []);
+    }, [page]);
     const contents = (children?.docs ?? []).map((child) => {
         return (
             <li key={(pid || "root") + "child" + child.id}>
@@ -42,7 +45,25 @@ const ChildList = ({ pid = "" }: ChildListProps): React.ReactElement => {
             </li>
         );
     });
-    return <ul>{contents}</ul>;
+    const pageCount = Math.ceil(children.numFound / pageSize);
+    const paginator =
+        pageCount > 1 ? (
+            <Pagination
+                count={pageCount}
+                page={page}
+                onChange={(e, page) => {
+                    setPage(page);
+                }}
+            />
+        ) : (
+            ""
+        );
+    return (
+        <>
+            {paginator}
+            <ul>{contents}</ul>
+        </>
+    );
 };
 
 export default ChildList;

--- a/client/components/edit/__snapshots__/ChildList.test.tsx.snap
+++ b/client/components/edit/__snapshots__/ChildList.test.tsx.snap
@@ -1,5 +1,171 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ChildList displays a paginator when appropriate 1`] = `
+<FetchContextProvider>
+  <ChildList>
+    <Component
+      count={1000}
+      onChange={[Function]}
+      page={1}
+    >
+      Pagination
+    </Component>
+    <ul>
+      <li
+        key="rootchildfoo:124"
+      >
+        <Link
+          href="/edit/object/foo:124"
+        >
+          <a
+            href="/edit/object/foo:124"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+          >
+            hello1 [foo:124]
+          </a>
+        </Link>
+      </li>
+      <li
+        key="rootchildfoo:125"
+      >
+        <Link
+          href="/edit/object/foo:125"
+        >
+          <a
+            href="/edit/object/foo:125"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+          >
+            hello2 [foo:125]
+          </a>
+        </Link>
+      </li>
+      <li
+        key="rootchildfoo:126"
+      >
+        <Link
+          href="/edit/object/foo:126"
+        >
+          <a
+            href="/edit/object/foo:126"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+          >
+            hello3 [foo:126]
+          </a>
+        </Link>
+      </li>
+      <li
+        key="rootchildfoo:127"
+      >
+        <Link
+          href="/edit/object/foo:127"
+        >
+          <a
+            href="/edit/object/foo:127"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+          >
+            hello4 [foo:127]
+          </a>
+        </Link>
+      </li>
+      <li
+        key="rootchildfoo:128"
+      >
+        <Link
+          href="/edit/object/foo:128"
+        >
+          <a
+            href="/edit/object/foo:128"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+          >
+            hello5 [foo:128]
+          </a>
+        </Link>
+      </li>
+      <li
+        key="rootchildfoo:129"
+      >
+        <Link
+          href="/edit/object/foo:129"
+        >
+          <a
+            href="/edit/object/foo:129"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+          >
+            hello6 [foo:129]
+          </a>
+        </Link>
+      </li>
+      <li
+        key="rootchildfoo:130"
+      >
+        <Link
+          href="/edit/object/foo:130"
+        >
+          <a
+            href="/edit/object/foo:130"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+          >
+            hello7 [foo:130]
+          </a>
+        </Link>
+      </li>
+      <li
+        key="rootchildfoo:131"
+      >
+        <Link
+          href="/edit/object/foo:131"
+        >
+          <a
+            href="/edit/object/foo:131"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+          >
+            hello8 [foo:131]
+          </a>
+        </Link>
+      </li>
+      <li
+        key="rootchildfoo:132"
+      >
+        <Link
+          href="/edit/object/foo:132"
+        >
+          <a
+            href="/edit/object/foo:132"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+          >
+            hello9 [foo:132]
+          </a>
+        </Link>
+      </li>
+      <li
+        key="rootchildfoo:133"
+      >
+        <Link
+          href="/edit/object/foo:133"
+        >
+          <a
+            href="/edit/object/foo:133"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+          >
+            hello10 [foo:133]
+          </a>
+        </Link>
+      </li>
+    </ul>
+  </ChildList>
+</FetchContextProvider>
+`;
+
 exports[`ChildList renders using ajax-loaded object data 1`] = `
 <FetchContextProvider>
   <ChildList

--- a/client/util/routes.ts
+++ b/client/util/routes.ts
@@ -34,8 +34,9 @@ const getPidActionUrl = (pid: string, action: string): string => {
     return `${editObjectUrl}/${encodeURIComponent(pid)}/${action}`;
 }
 
-const getObjectChildrenUrl = (pid: string): string => {
-    return pid.length > 0 ? getPidActionUrl(pid, "children") : `${apiUrl}/edit/topLevelObjects`;
+const getObjectChildrenUrl = (pid: string, start = 0, rows = 10): string => {
+    const base = pid.length > 0 ? getPidActionUrl(pid, "children") : `${apiUrl}/edit/topLevelObjects`;
+    return `${base}?start=${start}&rows=${rows}`;
 }
 
 const getObjectDetailsUrl = (pid: string): string => {


### PR DESCRIPTION
I'm planning on enhancing child lists in the near future -- right now, they are only displaying raw data from the Solr index, but I plan to add more detailed child components that pull additional data from other places (e.g. thumbnails from Fedora). Since loading extra data will be more expensive, we can't have hundreds or thousands of them displaying at once -- thus, I am introducing a pagination component to constrain the scope.