### PR TITLE
Clear config for tests.

### DIFF
--- a/api/src/models/FedoraDataCollection.test.ts
+++ b/api/src/models/FedoraDataCollection.test.ts
@@ -1,7 +1,9 @@
+import Config from "./Config";
 import FedoraDataCollection from "./FedoraDataCollection";
 
 let fedoraData;
 beforeEach(() => {
+    Config.setInstance(new Config({}));
     fedoraData = FedoraDataCollection.build("foo:123");
 });
 

--- a/api/src/services/FedoraDataCollector.test.ts
+++ b/api/src/services/FedoraDataCollector.test.ts
@@ -1,3 +1,4 @@
+import Config from "../models/Config";
 import Fedora from "./Fedora";
 import FedoraDataCollector from "./FedoraDataCollector";
 import MetadataExtractor from "./MetadataExtractor";
@@ -5,6 +6,7 @@ import MetadataExtractor from "./MetadataExtractor";
 describe("FedoraDataCollector", () => {
     let collector;
     beforeEach(() => {
+        Config.setInstance(new Config({}));
         collector = FedoraDataCollector.getInstance();
     });
 


### PR DESCRIPTION
I noticed that some tests were complaining about a missing vudl.ini in CI, but we don't want tests to try to access real configuration files. This explicitly sets the configuration to empty for the offending tests.