### PR TITLE
Do not run inline code when importing authRouter.

### DIFF
--- a/api/src/routes/auth.test.ts
+++ b/api/src/routes/auth.test.ts
@@ -1,12 +1,13 @@
 import * as request from "supertest";
 import { StatusCodes } from "http-status-codes";
 import app from "../app";
-import { authRouter } from "./auth";
+import { getAuthRouter } from "./auth";
 import Config from "../models/Config";
 
 describe("index", () => {
     beforeAll(() => {
-        app.use("/auth", authRouter);
+        Config.setInstance(new Config({}));
+        app.use("/auth", getAuthRouter());
     });
     beforeEach(() => {
         Config.setInstance(new Config({}));

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -14,7 +14,7 @@ import messengerRouter from "./routes/messenger";
 import ingestRouter from "./routes/ingest";
 import queueRouter from "./routes/queue";
 import indexRouter from "./routes/index";
-import { requireLogin, authRouter } from "./routes/auth";
+import { requireLogin, getAuthRouter } from "./routes/auth";
 import Authentication from "./services/Authentication";
 
 // TODO: Config?
@@ -29,7 +29,7 @@ app.use(session(sess));
 Authentication.getInstance().initializePassport();
 
 app.use("/", indexRouter);
-app.use("/api/auth", authRouter);
+app.use("/api/auth", getAuthRouter());
 app.use("/api/ingest", ingestRouter);
 app.use("/api/edit", editRouter);
 app.use("/messenger", messengerRouter);


### PR DESCRIPTION
There were some console warnings being included in test output because the simple act of importing the auth router was causing configuration loading to occur. I think having these kinds of inline code side effects from imports is undesirable, so I wrapped up the router initialization logic in a function to provide more control over when the code actually executes.