### PR TITLE
Fix paginator bug; improve types

### DIFF
--- a/client/hooks/usePaginatorControls.ts
+++ b/client/hooks/usePaginatorControls.ts
@@ -9,6 +9,10 @@ const usePaginatorControls = (currentPage: number, getMagicLabel: (page: number)
 
     const setControlsLabel = (label: string): void => {
         setLabel(currentPage, label);
+        // After saving the label, clear the input so we defer to the magic labeler;
+        // otherwise, the system can get into a confused state (where, for example,
+        // toggling brackets after entering a number by hand will not work).
+        setLabelInput("");
     };
 
     const approveCurrentPageLabel = (): void => {
@@ -44,7 +48,6 @@ const usePaginatorControls = (currentPage: number, getMagicLabel: (page: number)
     };
 
     const updateCurrentPageLabel = (event): void => {
-        setLabelInput(event.target.value);
         setControlsLabel(event.target.value);
     };
 

--- a/client/hooks/usePaginatorControls.ts
+++ b/client/hooks/usePaginatorControls.ts
@@ -1,44 +1,41 @@
 import { useState } from "react";
 import MagicLabeler from "../util/MagicLabeler";
 
-const usePaginatorControls = (currentPage, getMagicLabel, setLabel) => {
+const usePaginatorControls = (currentPage: number, getMagicLabel: (page: number) => string, setLabel: (page: number, label: string) => void) => {
     const [labelInput, setLabelInput] = useState("");
-    const getControlsLabel = (useMagic) => {
-        if (typeof useMagic === "undefined") {
-            useMagic = true;
-        }
-        return labelInput.length === 0 && useMagic ? getMagicLabel(currentPage) : labelInput;
+    const getControlsLabel = (): string => {
+        return labelInput.length === 0 ? getMagicLabel(currentPage) : labelInput;
     };
 
-    const setControlsLabel = (label) => {
+    const setControlsLabel = (label: string): void => {
         setLabel(currentPage, label);
     };
 
-    const approveCurrentPageLabel = () => {
-        setControlsLabel(getControlsLabel(true));
+    const approveCurrentPageLabel = (): void => {
+        setControlsLabel(getControlsLabel());
     };
 
-    const setLabelPrefix = (str) => {
+    const setLabelPrefix = (str: string): void => {
         setControlsLabel(MagicLabeler.replaceLabelPart(getControlsLabel(), "prefix", str, true));
     };
 
-    const setLabelBody = (str) => {
+    const setLabelBody = (str: string): void => {
         setControlsLabel(MagicLabeler.replaceLabelPart(getControlsLabel(), "label", str));
     };
 
-    const setLabelSuffix = (str) => {
+    const setLabelSuffix = (str: string): void => {
         setControlsLabel(MagicLabeler.replaceLabelPart(getControlsLabel(), "suffix", str, true));
     };
 
-    const toggleBrackets = () => {
+    const toggleBrackets = (): void => {
         setControlsLabel(MagicLabeler.toggleBrackets(getControlsLabel()));
     };
 
-    const toggleCase = () => {
+    const toggleCase = (): void => {
         setControlsLabel(MagicLabeler.toggleCase(getControlsLabel()));
     };
 
-    const toggleRoman = () => {
+    const toggleRoman = (): void => {
         var label = MagicLabeler.toggleRoman(getControlsLabel());
         if (label === false) {
             return alert("Roman numeral toggle not supported for this label.");
@@ -46,7 +43,7 @@ const usePaginatorControls = (currentPage, getMagicLabel, setLabel) => {
         setControlsLabel(label);
     };
 
-    const updateCurrentPageLabel = (event) => {
+    const updateCurrentPageLabel = (event): void => {
         setLabelInput(event.target.value);
         setControlsLabel(event.target.value);
     };

--- a/client/util/MagicLabeler.ts
+++ b/client/util/MagicLabeler.ts
@@ -1,12 +1,18 @@
-// TODO: `Add typing`
 import RomanNumerals from "roman-numerals";
+
+interface PageLabel {
+    prefix: string;
+    label: string;
+    suffix: string;
+    brackets: boolean;
+}
 
 var MagicLabeler = {
     prefixes: ["Front ", "Inside front ", "Rear ", "Inside rear "],
     labels: ["Blank", "cover", "fly leaf", "pastedown", "Frontispiece", "Plate"],
     suffixes: [", recto", ", verso", ", front", ", back"],
 
-    adjustNumericLabel: function (prior, delta) {
+    adjustNumericLabel: function (prior: string, delta: number) {
         // If it's an integer, this is simple:
         if (parseInt(prior) > 0) {
             return parseInt(prior) + delta;
@@ -28,7 +34,7 @@ var MagicLabeler = {
         return false;
     },
 
-    getLabelFromPrevPage: function (p, getLabelCallback) {
+    getLabelFromPrevPage: function (p: number, getLabelCallback: (i: number) => string): string {
         var bracketStatus = null;
         var skipSuffixCheck = false;
         while (p > 0) {
@@ -68,22 +74,22 @@ var MagicLabeler = {
             p--;
             skipSuffixCheck = true;
         }
-        return 1;
+        return "1";
     },
 
-    getLabel: function (p, getLabelCallback) {
+    getLabel: function (p: number, getLabelCallback: (i: number) => string) {
         // Did some experimentation with getLabelFromNextPage to
         // complement getLabelFromPrevPage, but it winded up having
         // too much recursion and making things too slow.
         return this.getLabelFromPrevPage(p, getLabelCallback);
     },
 
-    assemblePageLabel: function (label) {
+    assemblePageLabel: function (label: PageLabel): string {
         var text = label["prefix"] + label["label"] + label["suffix"];
         return label["brackets"] ? "[" + text + "]" : text;
     },
 
-    parsePageLabel: function (text) {
+    parsePageLabel: function (text: string): PageLabel {
         var brackets = false;
         text = String(text);
         if (text.substring(0, 1) === "[" && text.substring(text.length - 1, text.length) === "]") {
@@ -117,26 +123,23 @@ var MagicLabeler = {
         };
     },
 
-    replaceLabelPart: function (label, part, replacement, allowToggle) {
-        if (typeof allowToggle === "undefined") {
-            allowToggle = false;
-        }
+    replaceLabelPart: function (label: string, part: string, replacement: string, allowToggle: boolean = false) {
         var parts = this.parsePageLabel(label);
         parts[part] = parts[part] === replacement && allowToggle ? "" : replacement;
         return this.assemblePageLabel(parts);
     },
 
-    toggleBrackets: function (text) {
+    toggleBrackets: function (text: string) {
         var label = this.parsePageLabel(text);
         label["brackets"] = !label["brackets"];
         return this.assemblePageLabel(label);
     },
 
-    toggleCase: function (label) {
+    toggleCase: function (label: string): string {
         return label === label.toLowerCase() ? label.toUpperCase() : label.toLowerCase();
     },
 
-    toggleRoman: function (text) {
+    toggleRoman: function (text: string): string | false {
         var label = this.parsePageLabel(text);
         if (parseInt(label["label"]) > 0) {
             label["label"] = RomanNumerals.toRoman(label["label"]);


### PR DESCRIPTION
I discovered that the paginator was not quite working right (some buttons didn't work, and sometimes labels from previous pages would bleed forward in unexpected ways). This PR fixes the problem in commit 2605733; since I added lots of types while troubleshooting the problem (5de94af) I'm including that work here as well.