### PR TITLE
Remove unused/broken Express boilerplate.

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -4,7 +4,6 @@
 
 import * as http from "http";
 import * as passport from "passport";
-import createError from "http-errors";
 import * as session from "express-session";
 import debug from "debug";
 
@@ -35,39 +34,20 @@ app.use("/api/edit", editRouter);
 app.use("/messenger", messengerRouter);
 app.use("/queue", passport.initialize(), passport.session(), requireLogin, queueRouter);
 
-// catch 404 and forward to error handler
-app.use(function (req, res, next) {
-    next(createError(404));
-});
-
-// error handler
-app.use(function (err, req, res) {
-    // set locals, only providing error in development
-    res.locals.message = err.message;
-    res.locals.error = req.app.get("env") === "development" ? err : {};
-
-    // render the error page
-    res.status(err.status || 500);
-    res.render("error");
-});
-
 /**
  * Get port from environment and store in Express.
  */
-
 const port = normalizePort(process.env.PORT || "9000");
 app.set("port", port);
 
 /**
  * Create HTTP server.
  */
-
 const server = http.createServer(app);
 
 /**
  * Listen on provided port, on all network interfaces.
  */
-
 server.listen(port, () => console.log("Express started on port " + port));
 server.on("error", onError);
 server.on("listening", onListening);
@@ -75,7 +55,6 @@ server.on("listening", onListening);
 /**
  * Normalize a port into a number, string, or false.
  */
-
 function normalizePort(val) {
     const port = parseInt(val, 10);
 
@@ -95,7 +74,6 @@ function normalizePort(val) {
 /**
  * Event listener for HTTP server "error" event.
  */
-
 function onError(error) {
     if (error.syscall !== "listen") {
         throw error;
@@ -121,7 +99,6 @@ function onError(error) {
 /**
  * Event listener for HTTP server "listening" event.
  */
-
 function onListening() {
     const apiDebug = debug("vudlprepjs:server");
     const addr = server.address();


### PR DESCRIPTION
Some of the server.ts setup code is derived from old boilerplate and was causing unhelpful error messages. Removing it makes things behave more predictably (e.g. you actually get 404 errors when you should get 404 errors, instead of a weird stack trace).