### PR TITLE
Allow long buffers in TikaExtractor.

### DIFF
--- a/api/src/services/TikaExtractor.test.ts
+++ b/api/src/services/TikaExtractor.test.ts
@@ -31,6 +31,6 @@ describe("TikaExtractor", () => {
         expect(deleteSpy).toHaveBeenCalledTimes(1);
         expect(deleteSpy).toHaveBeenCalledWith(filename);
         expect(execSync).toHaveBeenCalledTimes(1);
-        expect(execSync).toHaveBeenCalledWith("java -jar /tika.jar --text -eUTF8 foo");
+        expect(execSync).toHaveBeenCalledWith("java -jar /tika.jar --text -eUTF8 foo", { maxBuffer: Infinity });
     });
 });

--- a/api/src/services/TikaExtractor.ts
+++ b/api/src/services/TikaExtractor.ts
@@ -26,7 +26,7 @@ class TikaExtractor {
         const javaPath = this.config.javaPath;
         const tikaPath = this.config.tikaPath;
         const tikaCommand = javaPath + " -jar " + tikaPath + " --text -eUTF8 " + filename;
-        const result = execSync(tikaCommand).toString();
+        const result = execSync(tikaCommand, { maxBuffer: Infinity }).toString();
         fs.rmSync(filename); // clean up temp file; we're done now!
         return result;
     }


### PR DESCRIPTION
When indexing very large PDFs, a buffer limit could be encountered. We do not want to impose a limit on text length for indexing purposes, so this PR overrides the default.