### PR TITLE
Index fixes

### DIFF
--- a/api/src/models/FedoraDataCollection.test.ts
+++ b/api/src/models/FedoraDataCollection.test.ts
@@ -1,4 +1,3 @@
-import { assert } from "console";
 import Config from "./Config";
 import FedoraDataCollection from "./FedoraDataCollection";
 

--- a/api/src/models/FedoraDataCollection.test.ts
+++ b/api/src/models/FedoraDataCollection.test.ts
@@ -1,3 +1,4 @@
+import { assert } from "console";
 import Config from "./Config";
 import FedoraDataCollection from "./FedoraDataCollection";
 
@@ -27,6 +28,35 @@ describe("FedoraDataCollection", () => {
                 title: "",
                 parents: [{ pid: "parent:123", title: "", parents: [] }],
             });
+        });
+    });
+
+    describe("getAllHierarchyTops", () => {
+        it("returns the current object when it has no parents", () => {
+            expect(fedoraData.getAllHierarchyTops()).toEqual([fedoraData]);
+        });
+
+        it("recurses to the top of the tree when an object has parents", () => {
+            const parent = FedoraDataCollection.build("parent:123");
+            fedoraData.addParent(parent);
+            expect(fedoraData.getAllHierarchyTops()).toEqual([parent]);
+        });
+
+        it("recurses to the top of the tree when an object has grandparents", () => {
+            const grandparent = FedoraDataCollection.build("grandparent:123");
+            const parent = FedoraDataCollection.build("parent:123");
+            parent.addParent(grandparent);
+            fedoraData.addParent(parent);
+            expect(fedoraData.getAllHierarchyTops()).toEqual([grandparent]);
+        });
+
+        it("cuts tree traversal short when it encounters a top-level pid", () => {
+            Config.setInstance(new Config({ top_level_pids: ["grandparent:123"] }));
+            const grandparent = FedoraDataCollection.build("grandparent:123");
+            const parent = FedoraDataCollection.build("parent:123");
+            parent.addParent(grandparent);
+            fedoraData.addParent(parent);
+            expect(fedoraData.getAllHierarchyTops()).toEqual([parent]);
         });
     });
 

--- a/api/src/services/FedoraDataCollector.ts
+++ b/api/src/services/FedoraDataCollector.ts
@@ -44,7 +44,8 @@ class FedoraDataCollector {
             this.extractor.extractFedoraDatastreams(RDF),
             this.fedora,
             this.extractor,
-            this.tika
+            this.tika,
+            this.config
         );
     }
 

--- a/api/src/services/SolrIndexer.test.ts
+++ b/api/src/services/SolrIndexer.test.ts
@@ -260,7 +260,7 @@ describe("SolrIndexer", () => {
             dc_relation_str: "Relation",
             dc_source_str_mv: ["Source"],
             dc_title_str: title,
-            description: ["Description"],
+            description: "Description",
             fedora_parent_id_str_mv: [],
             format: ["Book"],
             has_order_str: "no",

--- a/api/src/services/SolrIndexer.ts
+++ b/api/src/services/SolrIndexer.ts
@@ -194,7 +194,6 @@ class SolrIndexer {
             author2: "dc.contributor_txt_mv",
             dc_collection_str_mv: "dc.collection_txt_mv", // possibly unused
             dc_source_str_mv: "dc.source_txt_mv",
-            description: "dc.description_txt_mv",
             format: "dc.format_txt_mv",
             publisher: "dc.publisher_txt_mv",
             publisher_str_mv: "dc.publisher_txt_mv",
@@ -216,6 +215,7 @@ class SolrIndexer {
             dc_date_str: "dc.date_txt_mv",
             dc_relation_str: "dc.relation_txt_mv",
             dc_title_str: "dc.title_txt_mv",
+            description: "dc.description_txt_mv",
             title: "dc.title_txt_mv",
             title_full: "dc.title_txt_mv",
             title_short: "dc.title_txt_mv",


### PR DESCRIPTION
This PR fixes a couple of minor problems discovered during a full test reindex of Villanova's repository.

1.) The "description" field is not multi-valued and so needs to be indexed with only the first value found in Fedora (normally there shouldn't be multiple values, but if it happens, it will no longer cause a fatal indexing error).

2.) The determination of hierarchy top values was not coded correctly and needed to account for configuration settings. The logic here now matches the original VuDL XSLT behavior.

TODO
- [x] Re-run full index and confirm correct results
- [x] Make sure all existing tests are passing
- [x] Ensure new code is covered by tests