### PR TITLE
Do not request MIME type for undefined datastreams.

### DIFF
--- a/client/components/edit/datastream/DatastreamControlButton.tsx
+++ b/client/components/edit/datastream/DatastreamControlButton.tsx
@@ -43,7 +43,7 @@ const DatastreamControlButton = ({
             }
             setLoading(false);
         };
-        if (modalState === "View") {
+        if (modalState === "View" && !disabled) {
             enableButton();
         }
     }, []);


### PR DESCRIPTION
I noticed that the datastream controls were making API calls to fetch MIME types for ALL buttons, even those associated with unpopulated datastreams. Requesting the MIME type for a datastream that does not exist results in a 404 from Fedora, which in turn results in a 500 (unexpected response) from the API. If no content is defined and the view button is disabled, there is no reason to make these extra HTTP requests.