### PR TITLE
Use BlurSavingTextField for more responsive Agent editing.

### DIFF
--- a/client/components/edit/datastream/DatastreamAgentsContentRow.test.tsx
+++ b/client/components/edit/datastream/DatastreamAgentsContentRow.test.tsx
@@ -86,7 +86,7 @@ describe("DatastreamAgentsContentRow", () => {
     it("changes a name", () => {
         const wrapper = mount(<DatastreamAgentsContentRow {...props} />);
         act(() => {
-            wrapper.find(".agentNameTextField input").simulate("change", { target: { value: "test" } });
+            wrapper.find(".agentNameTextField input").simulate("blur", { target: { value: "test" } });
             wrapper.update();
         });
 

--- a/client/components/edit/datastream/DatastreamAgentsContentRow.tsx
+++ b/client/components/edit/datastream/DatastreamAgentsContentRow.tsx
@@ -11,6 +11,8 @@ import DatastreamAgentsContentNotes from "./DatastreamAgentsContentNotes";
 import ButtonGroup from "@mui/material/ButtonGroup";
 import Paper from "@mui/material/Paper";
 
+import BlurSavingTextField from "../../shared/BlurSavingTextField";
+
 interface DatastreamAgentsContentRowProps {
     agent: {
         role: string;
@@ -42,6 +44,21 @@ const DatastreamAgentsContentRow = ({
     const { types, roles, defaults } = agentsCatalog;
     const { role, type, name, notes } = agent;
     const [expanded, setExpanded] = useState(initialExpand);
+    const nameFieldOptions = {
+        className: "agentNameTextField",
+        error: name === "",
+        label: namesHelperText,
+    };
+    const setName = (name) => {
+        const { role, type } = defaults;
+        if (agent.name === "" && agent.role === "") {
+            onRoleChange(role);
+        }
+        if (agent.name === "" && agent.type === "") {
+            onTypeChange(type);
+        }
+        onNameChange(name);
+    };
     return (
         <>
             <Grid container item xs={3}>
@@ -94,21 +111,10 @@ const DatastreamAgentsContentRow = ({
             </Grid>
             <Grid container item xs={5}>
                 <FormControl fullWidth={true}>
-                    <TextField
-                        className="agentNameTextField"
-                        error={name === ""}
+                    <BlurSavingTextField
+                        options={nameFieldOptions}
                         value={name}
-                        label={namesHelperText}
-                        onChange={(event) => {
-                            const { role, type } = defaults;
-                            if (agent.name === "" && agent.role === "") {
-                                onRoleChange(role);
-                            }
-                            if (agent.name === "" && agent.type === "") {
-                                onTypeChange(type);
-                            }
-                            onNameChange(event.target.value);
-                        }}
+                        setValue={setName}
                     />
                 </FormControl>
             </Grid>

--- a/client/components/edit/datastream/__snapshots__/DatastreamAgentsContentRow.test.tsx.snap
+++ b/client/components/edit/datastream/__snapshots__/DatastreamAgentsContentRow.test.tsx.snap
@@ -86,11 +86,15 @@ exports[`DatastreamAgentsContentRow renders 1`] = `
     <ForwardRef(FormControl)
       fullWidth={true}
     >
-      <ForwardRef(TextField)
-        className="agentNameTextField"
-        error={false}
-        label=""
-        onChange={[Function]}
+      <BlurSavingTextField
+        options={
+          Object {
+            "className": "agentNameTextField",
+            "error": false,
+            "label": "",
+          }
+        }
+        setValue={[Function]}
         value="test3"
       />
     </ForwardRef(FormControl)>

--- a/client/components/shared/BlurSavingTextField.tsx
+++ b/client/components/shared/BlurSavingTextField.tsx
@@ -4,9 +4,10 @@ import TextField from "@mui/material/TextField";
 export interface BlurSavingTextFieldProps {
     value: string;
     setValue: (value: string) => void;
+    options?: Record<string, unknown>;
 }
 
-const BlurSavingTextField = ({ value, setValue }: BlurSavingTextFieldProps): React.ReactElement => {
+const BlurSavingTextField = ({ value, setValue, options = {} }: BlurSavingTextFieldProps): React.ReactElement => {
     const [temporaryValue, setTemporaryValue] = useState(value);
     const handleBlurEvent = (event: React.ChangeEvent) => {
         setValue(event.target.value);
@@ -14,7 +15,7 @@ const BlurSavingTextField = ({ value, setValue }: BlurSavingTextFieldProps): Rea
     const handleChangeEvent = (event: React.ChangeEvent) => {
         setTemporaryValue(event.target.value);
     };
-    return <TextField value={temporaryValue} onChange={handleChangeEvent} onBlur={handleBlurEvent} />;
+    return <TextField value={temporaryValue} onChange={handleChangeEvent} onBlur={handleBlurEvent} {...options} />;
 };
 
 export default BlurSavingTextField;


### PR DESCRIPTION
Editing Agent text fields could be a bit laggy due to the validation calculations taking place during typing. This PR replaces the TextField with a BlurSavingTextField to improve responsiveness. It also expands BlurSavingTextField to support arbitrary extra attributes on the underlying TextField. The only downside is that error state doesn't go away until you move away from the input field, but this seems like a price worth paying to avoid lagginess while typing.