### PR TITLE
Process Metadata editor

### DIFF
--- a/api/src/models/Config.ts
+++ b/api/src/models/Config.ts
@@ -260,6 +260,10 @@ class Config {
     get redisLockDuration(): number {
         return parseInt(this.ini?.["queue"]?.["lockDuration"] ?? "30000");
     }
+
+    get toolPresets(): Array<Record<string, string>> {
+        return this.ini?.["tool_presets"] ?? [];
+    }
 }
 
 export default Config;

--- a/api/src/models/Config.ts
+++ b/api/src/models/Config.ts
@@ -261,6 +261,10 @@ class Config {
         return parseInt(this.ini?.["queue"]?.["lockDuration"] ?? "30000");
     }
 
+    get processMetadataDefaults(): Record<string, string> {
+        return this.ini?.["process_metadata_defaults"] ?? {};
+    }
+
     get toolPresets(): Array<Record<string, string>> {
         return this.ini?.["tool_presets"] ?? [];
     }

--- a/api/src/models/FedoraObject.test.ts
+++ b/api/src/models/FedoraObject.test.ts
@@ -210,4 +210,49 @@ describe("FedoraObject", () => {
             expect(deleteDatastreamTombstoneSpy).toHaveBeenCalledWith(pid, stream);
         });
     });
+
+    describe("putDatastream", () => {
+        let putDatastreamSpy;
+        beforeEach(() => {
+            putDatastreamSpy = jest.spyOn(Fedora.getInstance(), "putDatastream").mockImplementation(jest.fn());
+        });
+
+        it("proxies the Fedora service", async () => {
+            const params = { mimeType: "foo/bar" };
+            const expectedStatus = [204];
+            await fedoraObject.putDatastream("foo", params, "data", expectedStatus);
+            expect(putDatastreamSpy).toHaveBeenCalledWith(pid, "foo", "foo/bar", expectedStatus, "data");
+        });
+
+        it("logs messages", async () => {
+            const logSpy = jest.spyOn(fedoraObject, "log").mockImplementation(jest.fn());
+            const params = { mimeType: "foo/bar", logMessage: "log" };
+            const expectedStatus = [204];
+            await fedoraObject.putDatastream("foo", params, "data", expectedStatus);
+            expect(logSpy).toHaveBeenCalledWith("log");
+        });
+
+        it("does not support dsLabel or dsState parameters", async () => {
+            const params = { dsLabel: "foo", dsState: "bar" };
+            await expect(async () => {
+                await fedoraObject.putDatastream("foo", params, "bar", [200]);
+            }).rejects.toThrow("Unsupported parameter(s) passed to putDatastream()");
+        });
+    });
+
+    describe("createOrModifyDatastream", () => {
+        it("proxies putDatastream with appropriate status expectations", async () => {
+            const putSpy = jest.spyOn(fedoraObject, "putDatastream").mockImplementation(jest.fn());
+            await fedoraObject.createOrModifyDatastream("foo", { mimeType: "bar" }, "baz");
+            expect(putSpy).toHaveBeenCalledWith("foo", { mimeType: "bar" }, "baz", [201, 204]);
+        });
+    });
+
+    describe("modifyDatastream", () => {
+        it("proxies putDatastream with appropriate status expectations", async () => {
+            const putSpy = jest.spyOn(fedoraObject, "putDatastream").mockImplementation(jest.fn());
+            await fedoraObject.modifyDatastream("foo", { mimeType: "bar" }, "baz");
+            expect(putSpy).toHaveBeenCalledWith("foo", { mimeType: "bar" }, "baz", [204]);
+        });
+    });
 });

--- a/api/src/models/FedoraObject.ts
+++ b/api/src/models/FedoraObject.ts
@@ -245,9 +245,9 @@ export class FedoraObject {
         expectedStatus: Array<number>
     ): Promise<void> {
         if (typeof params.dsLabel !== "undefined" || typeof params.dsState !== "undefined") {
-            throw new Error("Unsupported parameter(s) passed to modifyDatastream()");
+            throw new Error("Unsupported parameter(s) passed to putDatastream()");
         }
-        this.log(params.logMessage);
+        this.log(params.logMessage ?? "");
         await this.fedora.putDatastream(this.pid, id, params.mimeType, expectedStatus, data);
     }
 
@@ -264,7 +264,7 @@ export class FedoraObject {
     }
 
     log(message: string): void {
-        if (this.logger) {
+        if (this.logger && message.length > 0) {
             this.logger.info(message);
         }
     }

--- a/api/src/models/FedoraObject.ts
+++ b/api/src/models/FedoraObject.ts
@@ -238,12 +238,25 @@ export class FedoraObject {
         return fs.readFileSync(targetXml).toString();
     }
 
-    async modifyDatastream(id: string, params: DatastreamParameters, data: string): Promise<void> {
+    async putDatastream(
+        id: string,
+        params: DatastreamParameters,
+        data: string,
+        expectedStatus: Array<number>
+    ): Promise<void> {
         if (typeof params.dsLabel !== "undefined" || typeof params.dsState !== "undefined") {
             throw new Error("Unsupported parameter(s) passed to modifyDatastream()");
         }
         this.log(params.logMessage);
-        await this.fedora.putDatastream(this.pid, id, params.mimeType, [204], data);
+        await this.fedora.putDatastream(this.pid, id, params.mimeType, expectedStatus, data);
+    }
+
+    async createOrModifyDatastream(id: string, params: DatastreamParameters, data: string): Promise<void> {
+        await this.putDatastream(id, params, data, [201, 204]);
+    }
+
+    async modifyDatastream(id: string, params: DatastreamParameters, data: string): Promise<void> {
+        await this.putDatastream(id, params, data, [204]);
     }
 
     async modifyObjectLabel(title: string): Promise<void> {

--- a/api/src/routes/edit.test.ts
+++ b/api/src/routes/edit.test.ts
@@ -45,6 +45,7 @@ describe("edit", () => {
                 dublinCoreFields: {},
                 licenses: {},
                 models: {},
+                processMetadataDefaults: {},
                 toolPresets: [],
                 favoritePids: {},
                 vufindUrl: "",

--- a/api/src/routes/edit.test.ts
+++ b/api/src/routes/edit.test.ts
@@ -45,6 +45,7 @@ describe("edit", () => {
                 dublinCoreFields: {},
                 licenses: {},
                 models: {},
+                toolPresets: [],
                 favoritePids: {},
                 vufindUrl: "",
             };

--- a/api/src/routes/edit.test.ts
+++ b/api/src/routes/edit.test.ts
@@ -368,10 +368,83 @@ describe("edit", () => {
         });
 
         it("sends an error status code", async () => {
-            datastreamManager.getAgents.mockRejectedValue("get license key fails");
+            datastreamManager.getAgents.mockRejectedValue("get agents fails");
 
             await request(app)
-                .get(`/edit/object/${pid}/datastream/${datastream}/license`)
+                .get(`/edit/object/${pid}/datastream/${datastream}/agents`)
+                .set("Authorization", "Bearer test")
+                .expect(StatusCodes.INTERNAL_SERVER_ERROR);
+        });
+    });
+
+    describe("post /object/:pid/datastream/:stream/processMetadata", () => {
+        let datastreamManager;
+        let processMetadata;
+        beforeEach(() => {
+            datastreamManager = {
+                uploadProcessMetadata: jest.fn(),
+            };
+            processMetadata = { foo: "bar" };
+            jest.spyOn(Database.getInstance(), "confirmToken").mockResolvedValue(true);
+            jest.spyOn(DatastreamManager, "getInstance").mockReturnValue(datastreamManager);
+        });
+
+        it("uploads metadata", async () => {
+            datastreamManager.uploadProcessMetadata.mockResolvedValue({});
+
+            await request(app)
+                .post(`/edit/object/${pid}/datastream/${datastream}/processMetadata`)
+                .set("Authorization", "Bearer test")
+                .send({ processMetadata })
+                .set("Accept", "application/json")
+                .expect(StatusCodes.OK);
+
+            expect(datastreamManager.uploadProcessMetadata).toHaveBeenCalledWith(pid, datastream, processMetadata);
+        });
+
+        it("sends an error status code", async () => {
+            datastreamManager.uploadProcessMetadata.mockRejectedValue("upload processMetadata failed");
+
+            await request(app)
+                .post(`/edit/object/${pid}/datastream/${datastream}/processMetadata`)
+                .set("Authorization", "Bearer test")
+                .send({ processMetadata })
+                .set("Accept", "application/json")
+                .expect(StatusCodes.INTERNAL_SERVER_ERROR);
+        });
+    });
+
+    describe("get /object/:pid/datastream/:stream/processMetadata", () => {
+        let datastreamManager;
+        let processMetadata;
+        beforeEach(() => {
+            datastreamManager = {
+                getProcessMetadata: jest.fn(),
+            };
+            processMetadata = { foo: "bar" };
+            jest.spyOn(Database.getInstance(), "confirmToken").mockResolvedValue(true);
+            jest.spyOn(DatastreamManager, "getInstance").mockReturnValue(datastreamManager);
+        });
+        afterEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it("gets the metadata", async () => {
+            datastreamManager.getProcessMetadata.mockResolvedValue(processMetadata);
+
+            const response = await request(app)
+                .get(`/edit/object/${pid}/datastream/${datastream}/processMetadata`)
+                .set("Authorization", "Bearer test")
+                .expect(StatusCodes.OK);
+            expect(response.body).toEqual(processMetadata);
+            expect(datastreamManager.getProcessMetadata).toHaveBeenCalledWith(pid, datastream);
+        });
+
+        it("sends an error status code", async () => {
+            datastreamManager.getProcessMetadata.mockRejectedValue("get processMetadata fails");
+
+            await request(app)
+                .get(`/edit/object/${pid}/datastream/${datastream}/processMetadata`)
                 .set("Authorization", "Bearer test")
                 .expect(StatusCodes.INTERNAL_SERVER_ERROR);
         });

--- a/api/src/routes/edit.ts
+++ b/api/src/routes/edit.ts
@@ -183,6 +183,24 @@ edit.post(
 );
 
 edit.post(
+    "/object/:pid/datastream/:stream/processMetadata",
+    requireToken,
+    bodyParser.json(),
+    datastreamSanitizer,
+    async (req, res) => {
+        try {
+            const { pid, stream } = req.params;
+            const { processMetadata } = req.body;
+            const datastream = DatastreamManager.getInstance();
+            await datastream.uploadProcessMetadata(pid, stream, processMetadata);
+            res.status(200).send("Upload process metadata success");
+        } catch (error) {
+            res.status(500).send(error.message);
+        }
+    }
+);
+
+edit.post(
     "/object/:pid/datastream/:stream/dublinCore",
     requireToken,
     bodyParser.json(),

--- a/api/src/routes/edit.ts
+++ b/api/src/routes/edit.ts
@@ -222,6 +222,17 @@ edit.get("/object/:pid/datastream/:stream/metadata", requireToken, datastreamSan
     }
 });
 
+edit.get("/object/:pid/datastream/:stream/processMetadata", requireToken, datastreamSanitizer, async (req, res) => {
+    try {
+        const { pid, stream } = req.params;
+        const datastream = DatastreamManager.getInstance();
+        const metadata = await datastream.getProcessMetadata(pid, stream);
+        res.status(200).send(metadata);
+    } catch (error) {
+        res.status(500).send(error.message);
+    }
+});
+
 edit.get("/topLevelObjects", requireToken, getChildren);
 edit.get("/object/:pid/children", requireToken, pidSanitizer, getChildren);
 edit.get("/object/:pid/lastChildPosition", requireToken, pidSanitizer, async (req, res) => {

--- a/api/src/services/DatastreamManager.test.ts
+++ b/api/src/services/DatastreamManager.test.ts
@@ -29,7 +29,9 @@ describe("DatastreamManager", () => {
         fedoraObjectBuildSpy = jest.spyOn(FedoraObject, "build");
         getDatastreamSpy = jest.spyOn(FedoraObject.prototype, "getDatastream").mockImplementation(jest.fn());
         modifyAgentsSpy = jest.spyOn(FedoraObject.prototype, "modifyAgents").mockImplementation(jest.fn());
-        createOrModifyDatastreamSpy = jest.spyOn(FedoraObject.prototype, "createOrModifyDatastream").mockImplementation(jest.fn());
+        createOrModifyDatastreamSpy = jest
+            .spyOn(FedoraObject.prototype, "createOrModifyDatastream")
+            .mockImplementation(jest.fn());
         modifyDatastreamSpy = jest.spyOn(FedoraObject.prototype, "modifyDatastream").mockImplementation(jest.fn());
         modifyLicenseSpy = jest.spyOn(FedoraObject.prototype, "modifyLicense").mockImplementation(jest.fn());
         modifyObjectLabelSpy = jest.spyOn(FedoraObject.prototype, "modifyObjectLabel").mockImplementation(jest.fn());

--- a/api/src/services/DatastreamManager.test.ts
+++ b/api/src/services/DatastreamManager.test.ts
@@ -7,6 +7,7 @@ import Config from "../models/Config";
 describe("DatastreamManager", () => {
     let config;
     let fedoraObjectBuildSpy;
+    let createOrModifyDatastreamSpy;
     let modifyDatastreamSpy;
     let modifyLicenseSpy;
     let modifyObjectLabelSpy;
@@ -28,6 +29,7 @@ describe("DatastreamManager", () => {
         fedoraObjectBuildSpy = jest.spyOn(FedoraObject, "build");
         getDatastreamSpy = jest.spyOn(FedoraObject.prototype, "getDatastream").mockImplementation(jest.fn());
         modifyAgentsSpy = jest.spyOn(FedoraObject.prototype, "modifyAgents").mockImplementation(jest.fn());
+        createOrModifyDatastreamSpy = jest.spyOn(FedoraObject.prototype, "createOrModifyDatastream").mockImplementation(jest.fn());
         modifyDatastreamSpy = jest.spyOn(FedoraObject.prototype, "modifyDatastream").mockImplementation(jest.fn());
         modifyLicenseSpy = jest.spyOn(FedoraObject.prototype, "modifyLicense").mockImplementation(jest.fn());
         modifyObjectLabelSpy = jest.spyOn(FedoraObject.prototype, "modifyObjectLabel").mockImplementation(jest.fn());
@@ -300,7 +302,7 @@ describe("DatastreamManager", () => {
         });
 
         it("performs appropriate updates", async () => {
-            modifyDatastreamSpy.mockResolvedValue("");
+            createOrModifyDatastreamSpy.mockResolvedValue("");
 
             await datastreamManager.uploadProcessMetadata(pid, stream, metadata);
 
@@ -337,7 +339,7 @@ describe("DatastreamManager", () => {
     <DIGIPROVMD:process_label>Digitize Original Item</DIGIPROVMD:process_label>
     <DIGIPROVMD:process_organization>Falvey Memorial Library, Villanova University</DIGIPROVMD:process_organization>
 </DIGIPROVMD:DIGIPROVMD>`;
-            expect(modifyDatastreamSpy).toHaveBeenCalledWith(stream, { mimeType: "text/xml" }, expectedXml);
+            expect(createOrModifyDatastreamSpy).toHaveBeenCalledWith(stream, { mimeType: "text/xml" }, expectedXml);
         });
     });
 

--- a/api/src/services/DatastreamManager.test.ts
+++ b/api/src/services/DatastreamManager.test.ts
@@ -433,7 +433,7 @@ describe("DatastreamManager", () => {
             getAgentsSpy = jest.spyOn(MetadataExtractor.prototype, "getAgents");
         });
 
-        it("returns a licenseKey", async () => {
+        it("returns agents", async () => {
             const agents = [
                 {
                     role: "test3",
@@ -451,6 +451,30 @@ describe("DatastreamManager", () => {
             expect(getDatastreamSpy).toHaveBeenCalledWith(stream);
             expect(getAgentsSpy).toHaveBeenCalledWith("testXml");
             expect(response).toEqual(agents);
+        });
+    });
+
+    describe("getProcessMetadata", () => {
+        let pid;
+        let stream;
+        let getProcessMetadataSpy;
+        beforeEach(() => {
+            pid = "test1";
+            stream = "test2";
+            getProcessMetadataSpy = jest.spyOn(MetadataExtractor.prototype, "getProcessMetadata");
+        });
+
+        it("returns process metadata", async () => {
+            const metadata = { foo: "bar" };
+            getDatastreamSpy.mockReturnValue("testXml");
+            getProcessMetadataSpy.mockReturnValue(metadata);
+
+            const response = await datastreamManager.getProcessMetadata(pid, stream);
+
+            expect(fedoraObjectBuildSpy).toHaveBeenCalledWith(pid);
+            expect(getDatastreamSpy).toHaveBeenCalledWith(stream);
+            expect(getProcessMetadataSpy).toHaveBeenCalledWith("testXml");
+            expect(response).toEqual(metadata);
         });
     });
 

--- a/api/src/services/DatastreamManager.test.ts
+++ b/api/src/services/DatastreamManager.test.ts
@@ -304,9 +304,9 @@ describe("DatastreamManager", () => {
 
             await datastreamManager.uploadProcessMetadata(pid, stream, metadata);
 
-            const expectedXml = `<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-<DIGIPROVMD:DIGIPROVMD xmlns:DIGIPROVMD=\"http://www.loc.gov/PMD\">
-    <DIGIPROVMD:task ID=\"1\">
+            const expectedXml = `<?xml version="1.0" encoding="UTF-8"?>
+<DIGIPROVMD:DIGIPROVMD xmlns:DIGIPROVMD="http://www.loc.gov/PMD">
+    <DIGIPROVMD:task ID="1">
         <DIGIPROVMD:task_label>task label 1</DIGIPROVMD:task_label>
         <DIGIPROVMD:task_description>task desc 1</DIGIPROVMD:task_description>
         <DIGIPROVMD:task_sequence>1</DIGIPROVMD:task_sequence>
@@ -319,7 +319,7 @@ describe("DatastreamManager", () => {
         <DIGIPROVMD:tool_serial_number>sn1</DIGIPROVMD:tool_serial_number>
         </DIGIPROVMD:tool>
     </DIGIPROVMD:task>
-    <DIGIPROVMD:task ID=\"2\">
+    <DIGIPROVMD:task ID="2">
         <DIGIPROVMD:task_label>task label 2</DIGIPROVMD:task_label>
         <DIGIPROVMD:task_description>task desc 2</DIGIPROVMD:task_description>
         <DIGIPROVMD:task_sequence>1</DIGIPROVMD:task_sequence>

--- a/api/src/services/DatastreamManager.ts
+++ b/api/src/services/DatastreamManager.ts
@@ -125,7 +125,7 @@ class DatastreamManager {
 
     async getProcessMetadata(pid: string, stream: string): Promise<object> {
         const fedoraObject = FedoraObject.build(pid);
-        const xml = await fedoraObject.getDatastreamMetadata(stream);
+        const xml = await fedoraObject.getDatastream(stream);
         const metadataExtractor = MetadataExtractor.getInstance();
         return metadataExtractor.getProcessMetadata(xml);
     }

--- a/api/src/services/DatastreamManager.ts
+++ b/api/src/services/DatastreamManager.ts
@@ -123,7 +123,7 @@ class DatastreamManager {
         return metadataExtractor.getAgents(xml);
     }
 
-    async getProcessMetadata(pid: string, stream: string): Promise<object> {
+    async getProcessMetadata(pid: string, stream: string): Promise<Record<string, unknown>> {
         const fedoraObject = FedoraObject.build(pid);
         const xml = await fedoraObject.getDatastream(stream);
         const metadataExtractor = MetadataExtractor.getInstance();

--- a/api/src/services/DatastreamManager.ts
+++ b/api/src/services/DatastreamManager.ts
@@ -147,7 +147,7 @@ class DatastreamManager {
             )}</DIGIPROVMD:process_organization>\n` +
             "</DIGIPROVMD:DIGIPROVMD>";
 
-        await fedoraObject.modifyDatastream(stream, { mimeType: "text/xml" }, xml);
+        await fedoraObject.createOrModifyDatastream(stream, { mimeType: "text/xml" }, xml);
     }
 
     async getLicenseKey(pid: string, stream: string): Promise<string> {

--- a/api/src/services/DatastreamManager.ts
+++ b/api/src/services/DatastreamManager.ts
@@ -109,25 +109,19 @@ class DatastreamManager {
         const fedoraObject = FedoraObject.build(pid);
         const tasks = ((metadata.tasks ?? []) as Array<Record<string, string>>)
             .map((task) => {
-                return (
-                    `    <DIGIPROVMD:task ID="${task.id ?? 1}">\n` +
-                    `        <DIGIPROVMD:task_label>${task.label ?? ""}</DIGIPROVMD:task_label>\n` +
-                    `        <DIGIPROVMD:task_description>${task.description ?? ""}</DIGIPROVMD:task_description>\n` +
-                    `        <DIGIPROVMD:task_sequence>${task.sequence ?? 1}</DIGIPROVMD:task_sequence>\n` +
-                    `        <DIGIPROVMD:task_individual>${task.individual ?? ""}</DIGIPROVMD:task_individual>\n` +
-                    "        <DIGIPROVMD:tool>\n" +
-                    `        <DIGIPROVMD:tool_label>${task.toolLabel ?? ""}</DIGIPROVMD:tool_label>\n` +
-                    `        <DIGIPROVMD:tool_description>${
-                        task.toolDescription ?? ""
-                    }</DIGIPROVMD:tool_description>\n` +
-                    `        <DIGIPROVMD:tool_make>${task.toolMake ?? ""}</DIGIPROVMD:tool_make>\n` +
-                    `        <DIGIPROVMD:tool_version>${task.toolVersion ?? ""}</DIGIPROVMD:tool_version>\n` +
-                    `        <DIGIPROVMD:tool_serial_number>${
-                        task.toolSerialNumber ?? ""
-                    }</DIGIPROVMD:tool_serial_number>\n` +
-                    "        </DIGIPROVMD:tool>\n" +
-                    "    </DIGIPROVMD:task>\n"
-                );
+                return `    <DIGIPROVMD:task ID="${task.id ?? 1}">
+        <DIGIPROVMD:task_label>${task.label ?? ""}</DIGIPROVMD:task_label>
+        <DIGIPROVMD:task_description>${task.description ?? ""}</DIGIPROVMD:task_description>
+        <DIGIPROVMD:task_sequence>${task.sequence ?? 1}</DIGIPROVMD:task_sequence>
+        <DIGIPROVMD:task_individual>${task.individual ?? ""}</DIGIPROVMD:task_individual>
+        <DIGIPROVMD:tool>
+        <DIGIPROVMD:tool_label>${task.toolLabel ?? ""}</DIGIPROVMD:tool_label>
+        <DIGIPROVMD:tool_description>${task.toolDescription ?? ""}</DIGIPROVMD:tool_description>
+        <DIGIPROVMD:tool_make>${task.toolMake ?? ""}</DIGIPROVMD:tool_make>
+        <DIGIPROVMD:tool_version>${task.toolVersion ?? ""}</DIGIPROVMD:tool_version>
+        <DIGIPROVMD:tool_serial_number>${task.toolSerialNumber ?? ""}</DIGIPROVMD:tool_serial_number>
+        </DIGIPROVMD:tool>
+    </DIGIPROVMD:task>\n`;
             })
             .join("");
         // Format an XML document and save it to the repository:

--- a/api/src/services/DatastreamManager.ts
+++ b/api/src/services/DatastreamManager.ts
@@ -123,6 +123,13 @@ class DatastreamManager {
         return metadataExtractor.getAgents(xml);
     }
 
+    async getProcessMetadata(pid: string, stream: string): Promise<object> {
+        const fedoraObject = FedoraObject.build(pid);
+        const xml = await fedoraObject.getDatastreamMetadata(stream);
+        const metadataExtractor = MetadataExtractor.getInstance();
+        return metadataExtractor.getProcessMetadata(xml);
+    }
+
     async deleteDatastream(pid: string, stream: string): Promise<void> {
         const fedoraObject = FedoraObject.build(pid);
         await fedoraObject.deleteDatastream(stream);

--- a/api/src/services/FedoraCatalog.test.ts
+++ b/api/src/services/FedoraCatalog.test.ts
@@ -45,6 +45,7 @@ describe("FedoraCatalog", () => {
                 favoritePids: {},
                 licenses: {},
                 models: {},
+                toolPresets: [],
                 vufindUrl: "",
             };
             expect(await FedoraCatalog.getInstance().getCompleteCatalog()).toEqual(expectedCatalog);
@@ -64,6 +65,7 @@ describe("FedoraCatalog", () => {
                 },
                 licenses: {},
                 models: {},
+                toolPresets: [],
                 vufindUrl: "",
             };
             const catalog = new FedoraCatalog(config, solr);
@@ -87,6 +89,7 @@ describe("FedoraCatalog", () => {
                 },
                 licenses: {},
                 models: {},
+                toolPresets: [],
                 vufindUrl: "",
             };
             const catalog = new FedoraCatalog(config, solr);

--- a/api/src/services/FedoraCatalog.test.ts
+++ b/api/src/services/FedoraCatalog.test.ts
@@ -45,6 +45,7 @@ describe("FedoraCatalog", () => {
                 favoritePids: {},
                 licenses: {},
                 models: {},
+                processMetadataDefaults: {},
                 toolPresets: [],
                 vufindUrl: "",
             };
@@ -65,6 +66,7 @@ describe("FedoraCatalog", () => {
                 },
                 licenses: {},
                 models: {},
+                processMetadataDefaults: {},
                 toolPresets: [],
                 vufindUrl: "",
             };
@@ -89,6 +91,7 @@ describe("FedoraCatalog", () => {
                 },
                 licenses: {},
                 models: {},
+                processMetadataDefaults: {},
                 toolPresets: [],
                 vufindUrl: "",
             };

--- a/api/src/services/FedoraCatalog.ts
+++ b/api/src/services/FedoraCatalog.ts
@@ -27,6 +27,7 @@ export interface CompleteCatalog {
     licenses: Record<string, License>;
     models: Record<string, FedoraModel>;
     favoritePids: Record<string, string>;
+    toolPresets: Array<Record<string, string>>;
     vufindUrl: string;
 }
 
@@ -49,7 +50,7 @@ class FedoraCatalog {
     }
 
     async getCompleteCatalog(): Promise<CompleteCatalog> {
-        const { models, licenses, agentDefaults, agentRoles, agentTypes, vufindUrl } = this.config;
+        const { models, licenses, agentDefaults, agentRoles, agentTypes, toolPresets, vufindUrl } = this.config;
         return {
             agents: {
                 defaults: agentDefaults,
@@ -60,6 +61,7 @@ class FedoraCatalog {
             favoritePids: await this.getFavoritePids(),
             models,
             licenses,
+            toolPresets,
             vufindUrl,
         };
     }

--- a/api/src/services/FedoraCatalog.ts
+++ b/api/src/services/FedoraCatalog.ts
@@ -27,6 +27,7 @@ export interface CompleteCatalog {
     licenses: Record<string, License>;
     models: Record<string, FedoraModel>;
     favoritePids: Record<string, string>;
+    processMetadataDefaults: Record<string, string>;
     toolPresets: Array<Record<string, string>>;
     vufindUrl: string;
 }
@@ -50,7 +51,16 @@ class FedoraCatalog {
     }
 
     async getCompleteCatalog(): Promise<CompleteCatalog> {
-        const { models, licenses, agentDefaults, agentRoles, agentTypes, toolPresets, vufindUrl } = this.config;
+        const {
+            models,
+            licenses,
+            agentDefaults,
+            agentRoles,
+            agentTypes,
+            processMetadataDefaults,
+            toolPresets,
+            vufindUrl,
+        } = this.config;
         return {
             agents: {
                 defaults: agentDefaults,
@@ -62,6 +72,7 @@ class FedoraCatalog {
             models,
             licenses,
             toolPresets,
+            processMetadataDefaults,
             vufindUrl,
         };
     }

--- a/api/src/services/MetadataExtractor.test.ts
+++ b/api/src/services/MetadataExtractor.test.ts
@@ -6,6 +6,79 @@ describe("MetadataExtractor", () => {
     beforeEach(() => {
         metadataExtractor = MetadataExtractor.getInstance();
     });
+
+    describe("getProcessMetadata", () => {
+        it("extracts details from XML", () => {
+            const xml = `
+                            <?xml version="1.0" encoding="UTF-8"?>
+                            <DIGIPROVMD:DIGIPROVMD xmlns:DIGIPROVMD="http://www.loc.gov/PMD">
+                                <DIGIPROVMD:task ID="1">
+                                    <DIGIPROVMD:task_label>task label 1</DIGIPROVMD:task_label>
+                                    <DIGIPROVMD:task_description>task desc 1</DIGIPROVMD:task_description>
+                                    <DIGIPROVMD:task_sequence>1</DIGIPROVMD:task_sequence>
+                                    <DIGIPROVMD:task_individual>task indiv 1</DIGIPROVMD:task_individual>
+                                    <DIGIPROVMD:tool>
+                                    <DIGIPROVMD:tool_label>Photoshop</DIGIPROVMD:tool_label>
+                                    <DIGIPROVMD:tool_description>desc 1</DIGIPROVMD:tool_description>
+                                    <DIGIPROVMD:tool_make>Adobe</DIGIPROVMD:tool_make>
+                                    <DIGIPROVMD:tool_version>CS2</DIGIPROVMD:tool_version>
+                                    <DIGIPROVMD:tool_serial_number>sn1</DIGIPROVMD:tool_serial_number>
+                                    </DIGIPROVMD:tool>
+                                </DIGIPROVMD:task>
+                                <DIGIPROVMD:task ID="2">
+                                    <DIGIPROVMD:task_label>task label 2</DIGIPROVMD:task_label>
+                                    <DIGIPROVMD:task_description>task desc 2</DIGIPROVMD:task_description>
+                                    <DIGIPROVMD:task_sequence>1</DIGIPROVMD:task_sequence>
+                                    <DIGIPROVMD:task_individual>task indiv 2</DIGIPROVMD:task_individual>
+                                    <DIGIPROVMD:tool>
+                                    <DIGIPROVMD:tool_label>Indus 5005 MAX LARGE FORMAT BOOK SCANNER</DIGIPROVMD:tool_label>
+                                    <DIGIPROVMD:tool_description>desc 2</DIGIPROVMD:tool_description>
+                                    <DIGIPROVMD:tool_make>ImageWare</DIGIPROVMD:tool_make>
+                                    <DIGIPROVMD:tool_version>LF-00207</DIGIPROVMD:tool_version>
+                                    <DIGIPROVMD:tool_serial_number>LF-00207</DIGIPROVMD:tool_serial_number>
+                                    </DIGIPROVMD:tool>
+                                </DIGIPROVMD:task>
+                                <DIGIPROVMD:process_creator>first</DIGIPROVMD:process_creator>
+                                <DIGIPROVMD:process_datetime>2022-10-05T07:00:00</DIGIPROVMD:process_datetime>
+                                <DIGIPROVMD:process_label>Digitize Original Item</DIGIPROVMD:process_label>
+                                <DIGIPROVMD:process_organization>Falvey Memorial Library, Villanova University</DIGIPROVMD:process_organization>
+                            </DIGIPROVMD:DIGIPROVMD>
+                        `;
+            expect(metadataExtractor.getProcessMetadata(xml)).toEqual({
+                processCreator: "first",
+                processDateTime: "2022-10-05T07:00:00",
+                processLabel: "Digitize Original Item",
+                processOrganization: "Falvey Memorial Library, Villanova University",
+                tasks: [
+                    {
+                        description: "task desc 1",
+                        id: "1",
+                        individual: "task indiv 1",
+                        label: "task label 1",
+                        sequence: "1",
+                        toolDescription: "desc 1",
+                        toolLabel: "Photoshop",
+                        toolMake: "Adobe",
+                        toolSerialNumber: "sn1",
+                        toolVersion: "CS2",
+                    },
+                    {
+                        description: "task desc 2",
+                        id: "2",
+                        individual: "task indiv 2",
+                        label: "task label 2",
+                        sequence: "1",
+                        toolDescription: "desc 2",
+                        toolLabel: "Indus 5005 MAX LARGE FORMAT BOOK SCANNER",
+                        toolMake: "ImageWare",
+                        toolSerialNumber: "LF-00207",
+                        toolVersion: "LF-00207",
+                    },
+                ],
+            });
+        });
+    });
+
     describe("extractFedoraDetails", () => {
         it("extracts details from RDF", () => {
             const rdf = `

--- a/api/src/services/MetadataExtractor.ts
+++ b/api/src/services/MetadataExtractor.ts
@@ -235,6 +235,17 @@ class MetadataExtractor {
     }
 
     /**
+     * Extract process metadata details from the PROCESS-MD datastream.
+     *
+     * @param xml PROCESS-MD datastream XML
+     * @returns   Process details
+     */
+     public getProcessMetadata(xml: string): object {
+        // TODO
+        return {};
+    }
+
+    /**
      * Extract useful details from FITS technical metadata.
      *
      * @param xml FITS technical metadata

--- a/api/src/services/MetadataExtractor.ts
+++ b/api/src/services/MetadataExtractor.ts
@@ -241,8 +241,28 @@ class MetadataExtractor {
      * @returns   Process details
      */
      public getProcessMetadata(xml: string): object {
-        // TODO
-        return {};
+        const parsedXml = this.xmlParser.parseFromString(xml, "text/xml");
+        const namespaces = {
+            PMD: "http://www.loc.gov/PMD",
+        };
+        const rdfXPath = xpath.useNamespaces(namespaces);
+        // TODO: extract task sequence
+        const nodeMap = {
+            process_creator: "processCreator",
+            process_datetime: "processDateTime",
+            process_label: "processLabel",
+            process_organization: "processOrganization",
+        };
+        return rdfXPath("//PMD:process_creator|//PMD:process_datetime|//PMD:process_label|//PMD:process_organization", parsedXml).reduce(
+            (acc, relation: Element) => {
+                const target = nodeMap[relation.localName] ?? "";
+                if (target.length > 0) {
+                    acc[target] = relation.textContent;
+                }
+                return acc;
+            },
+            { processCreator: "", processDateTime: "", processLabel: "", processOrganization: "" }
+        );
     }
 
     /**

--- a/api/src/services/MetadataExtractor.ts
+++ b/api/src/services/MetadataExtractor.ts
@@ -263,7 +263,6 @@ class MetadataExtractor {
             PMD: "http://www.loc.gov/PMD",
         };
         const xpathProcessor = xpath.useNamespaces(namespaces);
-        // TODO: extract task sequence
         const tasks = xpathProcessor("//PMD:task", parsedXml).map((task: Element) => {
             const parsedTask = xpathProcessor("*|PMD:tool/*", task).reduce((acc, current: Element) => {
                 const target = taskNodeMap[current.localName] ?? "";

--- a/api/vudl.ini.dist
+++ b/api/vudl.ini.dist
@@ -427,6 +427,11 @@ type = "text"
 label = "Rights"
 type = "text"
 
+# You can set default values for top-level process metadata
+[process_metadata_defaults]
+processLabel = "Digitize Original Item"
+processOrganization = "My Library, My University"
+
 # You can set up tools as presets in the Process Metadata screen; just number each
 # uniquely in the section header (e.g. [tool_presets.0], [tool_presets.1], etc.)
 [tool_presets.0]

--- a/api/vudl.ini.dist
+++ b/api/vudl.ini.dist
@@ -427,6 +427,15 @@ type = "text"
 label = "Rights"
 type = "text"
 
+# You can set up tools as presets in the Process Metadata screen; just number each
+# uniquely in the section header (e.g. [tool_presets.0], [tool_presets.1], etc.)
+[tool_presets.0]
+label = "Example tool"
+serialNumber = "12345"
+description = "Just an example"
+make = "Example"
+version = "1"
+
 [queue]
 # This is the queue name that will be used for messages in Redis:
 defaultQueueName = "vudl"

--- a/client/components/edit/datastream/DatastreamProcessMetadataContent.test.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataContent.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { describe, afterEach, expect, it, jest } from "@jest/globals";
+import { shallow } from "enzyme";
+import toJson from "enzyme-to-json";
+import DatastreamProcessMetadataContent from "./DatastreamProcessMetadataContent";
+
+const mockUseEditorContext = jest.fn();
+jest.mock("../../../context/EditorContext", () => ({
+    useEditorContext: () => {
+        return mockUseEditorContext();
+    },
+}));
+
+const mockUseProcessMetadataContext = jest.fn();
+jest.mock("../../../context/ProcessMetadataContext", () => ({
+    useProcessMetadataContext: () => {
+        return mockUseProcessMetadataContext();
+    },
+}));
+
+const mockUseDatastreamOperation = jest.fn();
+jest.mock("../../../hooks/useDatastreamOperation", () => () => {
+    return mockUseDatastreamOperation();
+});
+
+jest.mock("./DatastreamProcessMetadataTask", () => () => "DatastreamProcessMetadataTask");
+
+describe("DatastreamProcessMetadataContent", () => {
+    let datastreamOperationValues;
+    let editorValues;
+    let processMetadataValues;
+
+    beforeEach(() => {
+        datastreamOperationValues = {
+            uploadProcessMetadata: jest.fn(),
+            getProcessMetadata: jest.fn(),
+        };
+        mockUseDatastreamOperation.mockReturnValue(datastreamOperationValues);
+        editorValues = { action: { toggleDatastreamModal: jest.fn() } };
+        mockUseEditorContext.mockReturnValue(editorValues);
+        processMetadataValues = {
+            state: {
+                processMetadata: {},
+            },
+            action: {
+                addTask: jest.fn(),
+                deleteTask: jest.fn(),
+                setMetadata: jest.fn(),
+                setProcessCreator: jest.fn(),
+                setProcessDateTime: jest.fn(),
+                setProcessLabel: jest.fn(),
+                setProcessOrganization: jest.fn(),
+                updateTaskAttributes: jest.fn(),
+            },
+        };
+        mockUseProcessMetadataContext.mockReturnValue(processMetadataValues);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("renders a loading message if content is unavailable", () => {
+        const wrapper = shallow(<DatastreamProcessMetadataContent />);
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/client/components/edit/datastream/DatastreamProcessMetadataContent.test.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataContent.test.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { describe, afterEach, expect, it, jest } from "@jest/globals";
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 import toJson from "enzyme-to-json";
 import DatastreamProcessMetadataContent from "./DatastreamProcessMetadataContent";
+import { waitFor } from "@testing-library/react";
 
 const mockUseEditorContext = jest.fn();
 jest.mock("../../../context/EditorContext", () => ({
@@ -63,6 +64,20 @@ describe("DatastreamProcessMetadataContent", () => {
     it("renders a loading message if content is unavailable", () => {
         const wrapper = shallow(<DatastreamProcessMetadataContent />);
 
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it("renders a form when data is loaded", async () => {
+        const fakeData = { foo: "bar" };
+        datastreamOperationValues.getProcessMetadata.mockResolvedValue(fakeData);
+
+        const wrapper = mount(<DatastreamProcessMetadataContent />);
+
+        await waitFor(() => expect(processMetadataValues.action.setMetadata).toHaveBeenCalledWith(fakeData));
+
+        expect(processMetadataValues.action.addTask).toHaveBeenCalledWith(0);
+
+        wrapper.update();
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 });

--- a/client/components/edit/datastream/DatastreamProcessMetadataContent.test.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataContent.test.tsx
@@ -25,7 +25,10 @@ jest.mock("../../../hooks/useDatastreamOperation", () => () => {
     return mockUseDatastreamOperation();
 });
 
-jest.mock("./DatastreamProcessMetadataTask", () => () => "DatastreamProcessMetadataTask");
+const DatastreamProcessMetadataTask = function DatastreamProcessMetadataTask() {
+    return "";
+};
+jest.mock("./DatastreamProcessMetadataTask", () => DatastreamProcessMetadataTask);
 
 describe("DatastreamProcessMetadataContent", () => {
     let datastreamOperationValues;
@@ -101,5 +104,24 @@ describe("DatastreamProcessMetadataContent", () => {
         const wrapper = await getMountedComponent();
         await wrapper.find(".uploadProcessMetadataButton").find(Button).props().onClick();
         expect(datastreamOperationValues.uploadProcessMetadata).toHaveBeenCalledWith(processMetadataValues.state);
+    });
+
+    it("supports task updates", async () => {
+        const wrapper = await getMountedComponent({ tasks: [{ id: 1 }] });
+        const attr = { foo: "bar" };
+        wrapper.find(DatastreamProcessMetadataTask).props().setAttributes(attr, true);
+        expect(processMetadataValues.action.updateTaskAttributes).toHaveBeenCalledWith(0, attr);
+    });
+
+    it("supports adding tasks", async () => {
+        const wrapper = await getMountedComponent({ tasks: [{ id: 1 }] });
+        wrapper.find(DatastreamProcessMetadataTask).props().addBelow();
+        expect(processMetadataValues.action.addTask).toHaveBeenCalledWith(1);
+    });
+
+    it("supports deleting tasks", async () => {
+        const wrapper = await getMountedComponent({ tasks: [{ id: 1 }] });
+        wrapper.find(DatastreamProcessMetadataTask).props().deleteTask();
+        expect(processMetadataValues.action.deleteTask).toHaveBeenCalledWith(0);
     });
 });

--- a/client/components/edit/datastream/DatastreamProcessMetadataContent.test.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataContent.test.tsx
@@ -30,6 +30,11 @@ const DatastreamProcessMetadataTask = function DatastreamProcessMetadataTask() {
 };
 jest.mock("./DatastreamProcessMetadataTask", () => DatastreamProcessMetadataTask);
 
+jest.mock("@mui/x-date-pickers", () => ({
+    DateTimePicker: () => "DateTimePicker",
+    LocalizationProvider: () => "LocalizationProvider",
+}));
+
 describe("DatastreamProcessMetadataContent", () => {
     let datastreamOperationValues;
     let editorValues;

--- a/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
@@ -34,7 +34,7 @@ const DatastreamProcessMetadataContent = (): React.ReactElement => {
             setProcessDateTime,
             setProcessLabel,
             setProcessOrganization,
-            updateTaskAttribute,
+            updateTaskAttributes,
         },
     } = useProcessMetadataContext();
     const [loading, setLoading] = useState<boolean>(true);
@@ -52,8 +52,12 @@ const DatastreamProcessMetadataContent = (): React.ReactElement => {
         loadProcessMetadata();
     }, []);
     const tasks = (processMetadata.tasks ?? []).map((task, i) => {
-        const callback = (attribute: string, value: string) => {
-            updateTaskAttribute(i, attribute, value);
+        const callback = (attributes: Record<string, string>, forceNewGeneration = false) => {
+            updateTaskAttributes(i, attributes);
+            // TODO: figure out why this is necessary!
+            if (forceNewGeneration) {
+                taskKeyGeneration++;
+            }
         };
         return (
             <DatastreamProcessMetadataTask
@@ -66,7 +70,7 @@ const DatastreamProcessMetadataContent = (): React.ReactElement => {
                     taskKeyGeneration++;
                     deleteTask(i);
                 }}
-                setAttribute={callback}
+                setAttributes={callback}
                 task={task}
             />
         );

--- a/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
@@ -54,7 +54,6 @@ const DatastreamProcessMetadataContent = (): React.ReactElement => {
     const tasks = (processMetadata.tasks ?? []).map((task, i) => {
         const callback = (attributes: Record<string, string>, forceNewGeneration = false) => {
             updateTaskAttributes(i, attributes);
-            // TODO: figure out why this is necessary!
             if (forceNewGeneration) {
                 taskKeyGeneration++;
             }

--- a/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
@@ -6,25 +6,76 @@ import FormControl from "@mui/material/FormControl";
 import FormLabel from "@mui/material/FormLabel";
 import useDatastreamOperation from "../../../hooks/useDatastreamOperation";
 import { useEditorContext } from "../../../context/EditorContext";
+import { useProcessMetadataContext } from "../../../context/ProcessMetadataContext";
+import BlurSavingTextField from "../../shared/BlurSavingTextField";
+import Grid from "@mui/material/Grid";
 
 const DatastreamProcessMetadataContent = (): React.ReactElement => {
     const {
         action: { toggleDatastreamModal },
     } = useEditorContext();
+    const {
+        state: processMetadata,
+        action: { setMetadata, setProcessCreator, setProcessDateTime, setProcessLabel, setProcessOrganization },
+    } = useProcessMetadataContext();
+    const [loading, setLoading] = useState<boolean>(true);
+
     const { uploadProcessMetadata, getProcessMetadata } = useDatastreamOperation();
-    const [processMetadata, setProcessMetadata] = useState([]);
     useEffect(() => {
         const loadProcessMetadata = async () => {
-            setProcessMetadata(await getProcessMetadata());
+            setMetadata(await getProcessMetadata());
+            setLoading(false);
         };
         loadProcessMetadata();
     }, []);
-    return (
+    return loading ? (
+        <DialogContent>Loading...</DialogContent>
+    ) : (
         <>
             <DialogContent>
                 <FormControl>
                     <FormLabel>Digital Provenance</FormLabel>
                 </FormControl>
+                <br />
+                <br />
+                <Grid container spacing={1}>
+                    <Grid item xs={3}>
+                        <FormControl fullWidth={true}>
+                            <BlurSavingTextField
+                                options={{ label: "Process Label" }}
+                                value={processMetadata.processLabel ?? ""}
+                                setValue={setProcessLabel}
+                            />
+                        </FormControl>
+                    </Grid>
+                    <Grid item xs={3}>
+                        <FormControl fullWidth={true}>
+                            <BlurSavingTextField
+                                options={{ label: "Process Creator" }}
+                                value={processMetadata.processCreator ?? ""}
+                                setValue={setProcessCreator}
+                            />
+                        </FormControl>
+                    </Grid>
+                    <Grid item xs={3}>
+                        <FormControl fullWidth={true}>
+                            <BlurSavingTextField
+                                options={{ label: "Process Date/Time" }}
+                                value={processMetadata.processDateTime ?? ""}
+                                setValue={setProcessDateTime}
+                            />
+                        </FormControl>
+                    </Grid>
+                    <Grid item xs={3}>
+                        <FormControl fullWidth={true}>
+                            <BlurSavingTextField
+                                options={{ label: "Process Organization" }}
+                                value={processMetadata.processOrganization ?? ""}
+                                setValue={setProcessOrganization}
+                            />
+                        </FormControl>
+                    </Grid>
+                </Grid>
             </DialogContent>
 
             <DialogActions>

--- a/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
@@ -15,11 +15,6 @@ import { DateTimePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import type {} from "@mui/x-date-pickers/themeAugmentation";
 
-// Whenever a task is added or removed, we need to revise the keys on the task
-// components so that React renders correctly. This counter is incremented on each
-// task add/remove, and used as part of the keys on related components.
-let taskKeyGeneration = 0;
-
 const DatastreamProcessMetadataContent = (): React.ReactElement => {
     const {
         action: { toggleDatastreamModal },
@@ -52,22 +47,16 @@ const DatastreamProcessMetadataContent = (): React.ReactElement => {
         loadProcessMetadata();
     }, []);
     const tasks = (processMetadata.tasks ?? []).map((task, i) => {
-        const callback = (attributes: Record<string, string>, forceNewGeneration = false) => {
+        const callback = (attributes: Record<string, string>) => {
             updateTaskAttributes(i, attributes);
-            // TODO: figure out why this is necessary!
-            if (forceNewGeneration) {
-                taskKeyGeneration++;
-            }
         };
         return (
             <DatastreamProcessMetadataTask
-                key={`process_task_${taskKeyGeneration}_${i}`}
+                key={JSON.stringify(task)}
                 addBelow={() => {
-                    taskKeyGeneration++;
                     addTask(i + 1);
                 }}
                 deleteTask={() => {
-                    taskKeyGeneration++;
                     deleteTask(i);
                 }}
                 setAttributes={callback}

--- a/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
@@ -9,6 +9,9 @@ import { useEditorContext } from "../../../context/EditorContext";
 import { useProcessMetadataContext } from "../../../context/ProcessMetadataContext";
 import BlurSavingTextField from "../../shared/BlurSavingTextField";
 import Grid from "@mui/material/Grid";
+import DatastreamProcessMetadataTask from "./DatastreamProcessMetadataTask";
+
+let keyCounter = 0;
 
 const DatastreamProcessMetadataContent = (): React.ReactElement => {
     const {
@@ -28,17 +31,22 @@ const DatastreamProcessMetadataContent = (): React.ReactElement => {
         };
         loadProcessMetadata();
     }, []);
+    const tasks = (processMetadata.tasks ?? []).map((task, i) => {
+        keyCounter++;
+        const callback = (attribute, value) => {
+            alert(`Set ${attribute} to ${value} at index ${i}`);
+        };
+        return <DatastreamProcessMetadataTask key={`process_task_${keyCounter}`} setAttribute={callback} task={task} />;
+    });
     return loading ? (
         <DialogContent>Loading...</DialogContent>
     ) : (
         <>
             <DialogContent>
-                <FormControl>
+                <FormControl style={{ "margin-bottom": "10px" }}>
                     <FormLabel>Digital Provenance</FormLabel>
                 </FormControl>
-                <br />
-                <br />
-                <Grid container spacing={1}>
+                <Grid container spacing={1} style={{ "margin-bottom": "10px" }}>
                     <Grid item xs={3}>
                         <FormControl fullWidth={true}>
                             <BlurSavingTextField
@@ -76,6 +84,7 @@ const DatastreamProcessMetadataContent = (): React.ReactElement => {
                         </FormControl>
                     </Grid>
                 </Grid>
+                {tasks}
             </DialogContent>
 
             <DialogActions>

--- a/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
@@ -4,12 +4,16 @@ import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import FormControl from "@mui/material/FormControl";
 import FormLabel from "@mui/material/FormLabel";
+import TextField from "@mui/material/TextField";
 import useDatastreamOperation from "../../../hooks/useDatastreamOperation";
 import { useEditorContext } from "../../../context/EditorContext";
 import { useProcessMetadataContext } from "../../../context/ProcessMetadataContext";
 import BlurSavingTextField from "../../shared/BlurSavingTextField";
 import Grid from "@mui/material/Grid";
 import DatastreamProcessMetadataTask from "./DatastreamProcessMetadataTask";
+import { DateTimePicker, LocalizationProvider } from "@mui/x-date-pickers";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import type {} from "@mui/x-date-pickers/themeAugmentation";
 
 // Whenever a task is added or removed, we need to revise the keys on the task
 // components so that React renders correctly. This counter is incremented on each
@@ -54,8 +58,14 @@ const DatastreamProcessMetadataContent = (): React.ReactElement => {
         return (
             <DatastreamProcessMetadataTask
                 key={`process_task_${taskKeyGeneration}_${i}`}
-                addBelow={() => { taskKeyGeneration++ ; addTask(i + 1) }}
-                deleteTask={() => { taskKeyGeneration++; deleteTask(i) }}
+                addBelow={() => {
+                    taskKeyGeneration++;
+                    addTask(i + 1);
+                }}
+                deleteTask={() => {
+                    taskKeyGeneration++;
+                    deleteTask(i);
+                }}
                 setAttribute={callback}
                 task={task}
             />
@@ -66,7 +76,7 @@ const DatastreamProcessMetadataContent = (): React.ReactElement => {
     ) : (
         <>
             <DialogContent>
-                <FormControl style={{ "margin-bottom": "10px" }}>
+                <FormControl style={{ marginBottom: "10px" }}>
                     <FormLabel>Digital Provenance</FormLabel>
                 </FormControl>
                 <Grid container spacing={1} style={{ marginBottom: "10px" }}>
@@ -89,13 +99,14 @@ const DatastreamProcessMetadataContent = (): React.ReactElement => {
                         </FormControl>
                     </Grid>
                     <Grid item xs={3}>
-                        <FormControl fullWidth={true}>
-                            <BlurSavingTextField
-                                options={{ label: "Process Date/Time" }}
+                        <LocalizationProvider dateAdapter={AdapterDayjs}>
+                            <DateTimePicker
+                                renderInput={(props) => <TextField {...props} />}
+                                label="Process Date/Time"
                                 value={processMetadata.processDateTime ?? ""}
-                                setValue={setProcessDateTime}
+                                onChange={setProcessDateTime}
                             />
-                        </FormControl>
+                        </LocalizationProvider>
                     </Grid>
                     <Grid item xs={3}>
                         <FormControl fullWidth={true}>

--- a/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
@@ -15,6 +15,11 @@ import { DateTimePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import type {} from "@mui/x-date-pickers/themeAugmentation";
 
+// Whenever a task is added or removed, we need to revise the keys on the task
+// components so that React renders correctly. This counter is incremented on each
+// task add/remove, and used as part of the keys on related components.
+let taskKeyGeneration = 0;
+
 const DatastreamProcessMetadataContent = (): React.ReactElement => {
     const {
         action: { toggleDatastreamModal },
@@ -47,16 +52,22 @@ const DatastreamProcessMetadataContent = (): React.ReactElement => {
         loadProcessMetadata();
     }, []);
     const tasks = (processMetadata.tasks ?? []).map((task, i) => {
-        const callback = (attributes: Record<string, string>) => {
+        const callback = (attributes: Record<string, string>, forceNewGeneration = false) => {
             updateTaskAttributes(i, attributes);
+            // TODO: figure out why this is necessary!
+            if (forceNewGeneration) {
+                taskKeyGeneration++;
+            }
         };
         return (
             <DatastreamProcessMetadataTask
-                key={JSON.stringify(task)}
+                key={`process_task_${taskKeyGeneration}_${i}`}
                 addBelow={() => {
+                    taskKeyGeneration++;
                     addTask(i + 1);
                 }}
                 deleteTask={() => {
+                    taskKeyGeneration++;
                     deleteTask(i);
                 }}
                 setAttributes={callback}

--- a/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
@@ -27,6 +27,7 @@ const DatastreamProcessMetadataContent = (): React.ReactElement => {
             setProcessDateTime,
             setProcessLabel,
             setProcessOrganization,
+            updateTaskAttribute,
         },
     } = useProcessMetadataContext();
     const [loading, setLoading] = useState<boolean>(true);
@@ -41,8 +42,8 @@ const DatastreamProcessMetadataContent = (): React.ReactElement => {
     }, []);
     const tasks = (processMetadata.tasks ?? []).map((task, i) => {
         keyCounter++;
-        const callback = (attribute, value) => {
-            alert(`Set ${attribute} to ${value} at index ${i}`);
+        const callback = (attribute: string, value: string) => {
+            updateTaskAttribute(i, attribute, value);
         };
         return (
             <DatastreamProcessMetadataTask

--- a/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
@@ -19,7 +19,15 @@ const DatastreamProcessMetadataContent = (): React.ReactElement => {
     } = useEditorContext();
     const {
         state: processMetadata,
-        action: { setMetadata, setProcessCreator, setProcessDateTime, setProcessLabel, setProcessOrganization },
+        action: {
+            addTask,
+            deleteTask,
+            setMetadata,
+            setProcessCreator,
+            setProcessDateTime,
+            setProcessLabel,
+            setProcessOrganization,
+        },
     } = useProcessMetadataContext();
     const [loading, setLoading] = useState<boolean>(true);
 
@@ -36,7 +44,15 @@ const DatastreamProcessMetadataContent = (): React.ReactElement => {
         const callback = (attribute, value) => {
             alert(`Set ${attribute} to ${value} at index ${i}`);
         };
-        return <DatastreamProcessMetadataTask key={`process_task_${keyCounter}`} setAttribute={callback} task={task} />;
+        return (
+            <DatastreamProcessMetadataTask
+                key={`process_task_${keyCounter}`}
+                addBelow={() => addTask(i + 1)}
+                deleteTask={() => deleteTask(i)}
+                setAttribute={callback}
+                task={task}
+            />
+        );
     });
     return loading ? (
         <DialogContent>Loading...</DialogContent>
@@ -46,7 +62,7 @@ const DatastreamProcessMetadataContent = (): React.ReactElement => {
                 <FormControl style={{ "margin-bottom": "10px" }}>
                     <FormLabel>Digital Provenance</FormLabel>
                 </FormControl>
-                <Grid container spacing={1} style={{ "margin-bottom": "10px" }}>
+                <Grid container spacing={1} style={{ marginBottom: "10px" }}>
                     <Grid item xs={3}>
                         <FormControl fullWidth={true}>
                             <BlurSavingTextField
@@ -84,7 +100,7 @@ const DatastreamProcessMetadataContent = (): React.ReactElement => {
                         </FormControl>
                     </Grid>
                 </Grid>
-                {tasks}
+                {tasks.length > 0 ? tasks : <button onClick={() => addTask(0)}>Add Task</button>}
             </DialogContent>
 
             <DialogActions>

--- a/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
@@ -11,7 +11,10 @@ import BlurSavingTextField from "../../shared/BlurSavingTextField";
 import Grid from "@mui/material/Grid";
 import DatastreamProcessMetadataTask from "./DatastreamProcessMetadataTask";
 
-let keyCounter = 0;
+// Whenever a task is added or removed, we need to revise the keys on the task
+// components so that React renders correctly. This counter is incremented on each
+// task add/remove, and used as part of the keys on related components.
+let taskKeyGeneration = 0;
 
 const DatastreamProcessMetadataContent = (): React.ReactElement => {
     const {
@@ -41,15 +44,14 @@ const DatastreamProcessMetadataContent = (): React.ReactElement => {
         loadProcessMetadata();
     }, []);
     const tasks = (processMetadata.tasks ?? []).map((task, i) => {
-        keyCounter++;
         const callback = (attribute: string, value: string) => {
             updateTaskAttribute(i, attribute, value);
         };
         return (
             <DatastreamProcessMetadataTask
-                key={`process_task_${keyCounter}`}
-                addBelow={() => addTask(i + 1)}
-                deleteTask={() => deleteTask(i)}
+                key={`process_task_${taskKeyGeneration}_${i}`}
+                addBelow={() => { taskKeyGeneration++ ; addTask(i + 1) }}
+                deleteTask={() => { taskKeyGeneration++; deleteTask(i) }}
                 setAttribute={callback}
                 task={task}
             />

--- a/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
@@ -38,7 +38,11 @@ const DatastreamProcessMetadataContent = (): React.ReactElement => {
     const { uploadProcessMetadata, getProcessMetadata } = useDatastreamOperation();
     useEffect(() => {
         const loadProcessMetadata = async () => {
-            setMetadata(await getProcessMetadata());
+            const metadata = await getProcessMetadata();
+            setMetadata(metadata);
+            if ((metadata.tasks ?? []).length == 0) {
+                addTask(0);
+            }
             setLoading(false);
         };
         loadProcessMetadata();

--- a/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataContent.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from "react";
+import Button from "@mui/material/Button";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import FormControl from "@mui/material/FormControl";
+import FormLabel from "@mui/material/FormLabel";
+import useDatastreamOperation from "../../../hooks/useDatastreamOperation";
+import { useEditorContext } from "../../../context/EditorContext";
+
+const DatastreamProcessMetadataContent = (): React.ReactElement => {
+    const {
+        action: { toggleDatastreamModal },
+    } = useEditorContext();
+    const { uploadProcessMetadata, getProcessMetadata } = useDatastreamOperation();
+    const [processMetadata, setProcessMetadata] = useState([]);
+    useEffect(() => {
+        const loadProcessMetadata = async () => {
+            setProcessMetadata(await getProcessMetadata());
+        };
+        loadProcessMetadata();
+    }, []);
+    return (
+        <>
+            <DialogContent>
+                <FormControl>
+                    <FormLabel>Digital Provenance</FormLabel>
+                </FormControl>
+            </DialogContent>
+
+            <DialogActions>
+                <Button
+                    className="uploadProcessMetadataButton"
+                    onClick={async () => {
+                        await uploadProcessMetadata(processMetadata);
+                    }}
+                >
+                    Save
+                </Button>
+                <Button onClick={toggleDatastreamModal}>Cancel</Button>
+            </DialogActions>
+        </>
+    );
+};
+
+export default DatastreamProcessMetadataContent;

--- a/client/components/edit/datastream/DatastreamProcessMetadataTask.test.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataTask.test.tsx
@@ -3,10 +3,12 @@ import { describe, afterEach, expect, it, jest } from "@jest/globals";
 import { mount, shallow } from "enzyme";
 import toJson from "enzyme-to-json";
 import DatastreamProcessMetadataTask from "./DatastreamProcessMetadataTask";
+import BlurSavingTextField from "../../shared/BlurSavingTextField";
 import { ProcessMetadataTask } from "../../../context/ProcessMetadataContext";
 import Delete from "@mui/icons-material/Delete";
 import AddCircle from "@mui/icons-material/AddCircle";
 import { act } from "react-dom/test-utils";
+import NativeSelect from "@mui/material/NativeSelect";
 
 const mockUseEditorContext = jest.fn();
 jest.mock("../../../context/EditorContext", () => ({
@@ -68,6 +70,78 @@ describe("DatastreamProcessMetadataTask", () => {
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it("applies tool presets", () => {
+        editorValues.state.toolPresets.push({ label: "Tool 1" });
+        editorValues.state.toolPresets.push({ label: "Tool 2", serialNumber: "1234", version: "1" });
+        const setAttributes = jest.fn();
+        const wrapper = mount(
+            <DatastreamProcessMetadataTask
+                task={{}}
+                deleteTask={jest.fn()}
+                addBelow={jest.fn()}
+                setAttributes={setAttributes}
+            />
+        );
+
+        act(() => {
+            wrapper
+                .find(NativeSelect)
+                .props()
+                .onChange({ target: { value: "1" } });
+        });
+        wrapper.update();
+        act(() => {
+            wrapper.find("button").at(0).simulate("click");
+        });
+
+        expect(setAttributes).toHaveBeenCalledWith(
+            {
+                toolDescription: "",
+                toolLabel: "Tool 2",
+                toolMake: "",
+                toolSerialNumber: "1234",
+                toolVersion: "1",
+            },
+            true
+        );
+    });
+
+    it("saves values", () => {
+        const setAttributes = jest.fn();
+        const wrapper = mount(
+            <DatastreamProcessMetadataTask
+                task={task}
+                deleteTask={jest.fn()}
+                addBelow={jest.fn()}
+                setAttributes={setAttributes}
+            />
+        );
+
+        const attributes = [
+            "sequence",
+            "label",
+            "description",
+            "individual",
+            "toolLabel",
+            "toolDescription",
+            "toolMake",
+            "toolVersion",
+            "toolSerialNumber",
+        ];
+        act(() => {
+            attributes.forEach((value, index) => {
+                wrapper
+                    .find(BlurSavingTextField)
+                    .at(index)
+                    .props()
+                    .setValue(value + "foo");
+            });
+        });
+        attributes.forEach((value, index) => {
+            expect(setAttributes).toHaveBeenNthCalledWith(index + 1, { [value]: `${value}foo` });
+        });
     });
 
     it("deletes tasks", () => {

--- a/client/components/edit/datastream/DatastreamProcessMetadataTask.test.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataTask.test.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { describe, afterEach, expect, it, jest } from "@jest/globals";
+import { shallow } from "enzyme";
+import toJson from "enzyme-to-json";
+import DatastreamProcessMetadataTask from "./DatastreamProcessMetadataTask";
+import { ProcessMetadataTask } from "../../../context/ProcessMetadataContext";
+
+const mockUseEditorContext = jest.fn();
+jest.mock("../../../context/EditorContext", () => ({
+    useEditorContext: () => {
+        return mockUseEditorContext();
+    },
+}));
+
+describe("DatastreamProcessMetadataTask", () => {
+    let editorValues;
+    let task: ProcessMetadataTask;
+
+    beforeEach(() => {
+        editorValues = {
+            state: {
+                toolPresets: [],
+            },
+        };
+        task = {
+            sequence: "seq",
+            label: "lab",
+            description: "des",
+            individual: "ind",
+            toolLabel: "tool-lab",
+            toolDescription: "tool-des",
+            toolMake: "tool-mak",
+            toolVersion: "tool-ver",
+            toolSerialNumber: "tool-ser",
+        };
+        mockUseEditorContext.mockReturnValue(editorValues);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("renders without tool presets", () => {
+        const wrapper = shallow(
+            <DatastreamProcessMetadataTask
+                task={task}
+                deleteTask={jest.fn()}
+                addBelow={jest.fn()}
+                setAttributes={jest.fn()}
+            />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it("renders with tool presets", () => {
+        editorValues.state.toolPresets.push({ label: "My Tool" });
+        const wrapper = shallow(
+            <DatastreamProcessMetadataTask
+                task={task}
+                deleteTask={jest.fn()}
+                addBelow={jest.fn()}
+                setAttributes={jest.fn()}
+            />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/client/components/edit/datastream/DatastreamProcessMetadataTask.test.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataTask.test.tsx
@@ -1,9 +1,12 @@
 import React from "react";
 import { describe, afterEach, expect, it, jest } from "@jest/globals";
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 import toJson from "enzyme-to-json";
 import DatastreamProcessMetadataTask from "./DatastreamProcessMetadataTask";
 import { ProcessMetadataTask } from "../../../context/ProcessMetadataContext";
+import Delete from "@mui/icons-material/Delete";
+import AddCircle from "@mui/icons-material/AddCircle";
+import { act } from "react-dom/test-utils";
 
 const mockUseEditorContext = jest.fn();
 jest.mock("../../../context/EditorContext", () => ({
@@ -65,5 +68,39 @@ describe("DatastreamProcessMetadataTask", () => {
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it("deletes tasks", () => {
+        const deleteTask = jest.fn();
+        const wrapper = mount(
+            <DatastreamProcessMetadataTask
+                task={task}
+                deleteTask={deleteTask}
+                addBelow={jest.fn()}
+                setAttributes={jest.fn()}
+            />
+        );
+
+        act(() => {
+            wrapper.find(Delete).parent().props().onClick();
+        });
+        expect(deleteTask).toHaveBeenCalled();
+    });
+
+    it("inserts values below", () => {
+        const addBelow = jest.fn();
+        const wrapper = mount(
+            <DatastreamProcessMetadataTask
+                task={task}
+                deleteTask={jest.fn()}
+                addBelow={addBelow}
+                setAttributes={jest.fn()}
+            />
+        );
+
+        act(() => {
+            wrapper.find(AddCircle).parent().props().onClick();
+        });
+        expect(addBelow).toHaveBeenCalled();
     });
 });

--- a/client/components/edit/datastream/DatastreamProcessMetadataTask.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataTask.tsx
@@ -43,6 +43,35 @@ const DatastreamProcessMetadataTask = ({
             true
         );
     };
+    const toolPresetKeys = Object.keys(toolPresets);
+    const presetControl =
+        toolPresetKeys.length > 0 ? (
+            <>
+                <Grid item xs={7}>
+                    <FormControl fullWidth={true}>
+                        <label>
+                            Select a preset tool:
+                            <NativeSelect
+                                value={selectedTool}
+                                onChange={(event) => setSelectedTool(event.target.value)}
+                            >
+                                {toolPresetKeys.map((index: string) => {
+                                    const tool = toolPresets[index];
+                                    return (
+                                        <option key={`tool_preset_${index}`} value={index}>
+                                            {tool.label ?? ""}
+                                        </option>
+                                    );
+                                })}
+                            </NativeSelect>
+                        </label>
+                    </FormControl>
+                </Grid>
+                <Grid item xs={5}>
+                    <button onClick={applyToolPreset}>Apply Preset</button>
+                </Grid>
+            </>
+        ) : null;
     return (
         <>
             <hr style={{ marginBottom: "20px" }} />
@@ -85,29 +114,7 @@ const DatastreamProcessMetadataTask = ({
                                 />
                             </FormControl>
                         </Grid>
-                        <Grid item xs={7}>
-                            <FormControl fullWidth={true}>
-                                <label>
-                                    Select a preset tool:
-                                    <NativeSelect
-                                        value={selectedTool}
-                                        onChange={(event) => setSelectedTool(event.target.value)}
-                                    >
-                                        {Object.keys(toolPresets).map((index: number) => {
-                                            const tool = toolPresets[index];
-                                            return (
-                                                <option key={`tool_preset_${index}`} value={index}>
-                                                    {tool.label ?? ""}
-                                                </option>
-                                            );
-                                        })}
-                                    </NativeSelect>
-                                </label>
-                            </FormControl>
-                        </Grid>
-                        <Grid item xs={5}>
-                            <button onClick={applyToolPreset}>Apply Preset</button>
-                        </Grid>
+                        {presetControl}
                         <Grid item xs={3}>
                             <FormControl fullWidth={true}>
                                 <BlurSavingTextField

--- a/client/components/edit/datastream/DatastreamProcessMetadataTask.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataTask.tsx
@@ -28,7 +28,10 @@ const DatastreamProcessMetadataTask = ({
     const [selectedTool, setSelectedTool] = useState(Object.keys(toolPresets)[0] ?? "");
     const applyToolPreset = () => {
         const tool = toolPresets[selectedTool] ?? {};
-        // TODO: figure out why the second parameter (true) is necessary to trigger redraws
+        // When we apply tool presets, we need to force a redraw of the form by incrementing
+        // the "key generation" -- this is the purpose of the second parameter (true) below.
+        // This enables a compromise between redraws-when-needed and fast performance when
+        // users update the form via keyboard.
         setAttributes({
             toolLabel: tool.label ?? "",
             toolSerialNumber: tool.serialNumber ?? "",

--- a/client/components/edit/datastream/DatastreamProcessMetadataTask.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataTask.tsx
@@ -13,7 +13,7 @@ interface DatastreamProcessMetadataTaskProps {
     task: ProcessMetadataTask;
     deleteTask: () => void;
     addBelow: () => void;
-    setAttributes: (attributes: Record<string, string>, forceNewGeneration?: boolean) => void;
+    setAttributes: (attributes: Record<string, string>) => void;
 }
 
 const DatastreamProcessMetadataTask = ({
@@ -28,14 +28,13 @@ const DatastreamProcessMetadataTask = ({
     const [selectedTool, setSelectedTool] = useState(Object.keys(toolPresets)[0] ?? "");
     const applyToolPreset = () => {
         const tool = toolPresets[selectedTool] ?? {};
-        // TODO: figure out why the second parameter (true) is necessary to trigger redraws
         setAttributes({
             toolLabel: tool.label ?? "",
             toolSerialNumber: tool.serialNumber ?? "",
             toolDescription: tool.description ?? "",
             toolMake: tool.make ?? "",
             toolVersion: tool.version ?? "",
-        }, true);
+        });
     };
     return (
         <>

--- a/client/components/edit/datastream/DatastreamProcessMetadataTask.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataTask.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import FormControl from "@mui/material/FormControl";
+import { ProcessMetadataTask } from "../../../context/ProcessMetadataContext";
+import BlurSavingTextField from "../../shared/BlurSavingTextField";
+import Grid from "@mui/material/Grid";
+
+interface DatastreamProcessMetadataTaskProps {
+    task: ProcessMetadataTask;
+    setAttribute: (attribute: string, value: string) => void;
+}
+
+const DatastreamProcessMetadataTask = ({
+    task,
+    setAttribute,
+}: DatastreamProcessMetadataTaskProps): React.ReactElement => {
+    return (
+        <Grid container spacing={1} style={{ "margin-bottom": "10px" }}>
+            <Grid item xs={3}>
+                <FormControl fullWidth={true}>
+                    <BlurSavingTextField
+                        options={{ label: "Task Sequence" }}
+                        value={task.sequence ?? ""}
+                        setValue={(value) => setAttribute("sequence", value)}
+                    />
+                </FormControl>
+            </Grid>
+            <Grid item xs={3}>
+                <FormControl fullWidth={true}>
+                    <BlurSavingTextField
+                        options={{ label: "Task Label" }}
+                        value={task.label ?? ""}
+                        setValue={(value) => setAttribute("label", value)}
+                    />
+                </FormControl>
+            </Grid>
+            <Grid item xs={3}>
+                <FormControl fullWidth={true}>
+                    <BlurSavingTextField
+                        options={{ label: "Task Description" }}
+                        value={task.description ?? ""}
+                        setValue={(value) => setAttribute("description", value)}
+                    />
+                </FormControl>
+            </Grid>
+            <Grid item xs={3}>
+                <FormControl fullWidth={true}>
+                    <BlurSavingTextField
+                        options={{ label: "Task Individual" }}
+                        value={task.individual ?? ""}
+                        setValue={(value) => setAttribute("individual", value)}
+                    />
+                </FormControl>
+            </Grid>
+            <Grid item xs={3}>
+                <FormControl fullWidth={true}>
+                    <BlurSavingTextField
+                        options={{ label: "Task Tool" }}
+                        value={task.toolLabel ?? ""}
+                        setValue={(value) => setAttribute("toolLabel", value)}
+                    />
+                </FormControl>
+            </Grid>
+            <Grid item xs={3}>
+                <FormControl fullWidth={true}>
+                    <BlurSavingTextField
+                        options={{ label: "Tool Description" }}
+                        value={task.toolDescription ?? ""}
+                        setValue={(value) => setAttribute("toolDescription", value)}
+                    />
+                </FormControl>
+            </Grid>
+            <Grid item xs={2}>
+                <FormControl fullWidth={true}>
+                    <BlurSavingTextField
+                        options={{ label: "Tool Make" }}
+                        value={task.toolMake ?? ""}
+                        setValue={(value) => setAttribute("toolMake", value)}
+                    />
+                </FormControl>
+            </Grid>
+            <Grid item xs={2}>
+                <FormControl fullWidth={true}>
+                    <BlurSavingTextField
+                        options={{ label: "Tool Version" }}
+                        value={task.toolVersion ?? ""}
+                        setValue={(value) => setAttribute("toolVersion", value)}
+                    />
+                </FormControl>
+            </Grid>
+            <Grid item xs={2}>
+                <FormControl fullWidth={true}>
+                    <BlurSavingTextField
+                        options={{ label: "Tool Serial Number" }}
+                        value={task.toolSerialNumber ?? ""}
+                        setValue={(value) => setAttribute("toolSerialNumber", value)}
+                    />
+                </FormControl>
+            </Grid>
+        </Grid>
+    );
+};
+
+export default DatastreamProcessMetadataTask;

--- a/client/components/edit/datastream/DatastreamProcessMetadataTask.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataTask.tsx
@@ -13,7 +13,7 @@ interface DatastreamProcessMetadataTaskProps {
     task: ProcessMetadataTask;
     deleteTask: () => void;
     addBelow: () => void;
-    setAttributes: (attributes: Record<string, string>) => void;
+    setAttributes: (attributes: Record<string, string>, forceNewGeneration?: boolean) => void;
 }
 
 const DatastreamProcessMetadataTask = ({
@@ -28,13 +28,14 @@ const DatastreamProcessMetadataTask = ({
     const [selectedTool, setSelectedTool] = useState(Object.keys(toolPresets)[0] ?? "");
     const applyToolPreset = () => {
         const tool = toolPresets[selectedTool] ?? {};
+        // TODO: figure out why the second parameter (true) is necessary to trigger redraws
         setAttributes({
             toolLabel: tool.label ?? "",
             toolSerialNumber: tool.serialNumber ?? "",
             toolDescription: tool.description ?? "",
             toolMake: tool.make ?? "",
             toolVersion: tool.version ?? "",
-        });
+        }, true);
     };
     return (
         <>

--- a/client/components/edit/datastream/DatastreamProcessMetadataTask.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataTask.tsx
@@ -32,13 +32,16 @@ const DatastreamProcessMetadataTask = ({
         // the "key generation" -- this is the purpose of the second parameter (true) below.
         // This enables a compromise between redraws-when-needed and fast performance when
         // users update the form via keyboard.
-        setAttributes({
-            toolLabel: tool.label ?? "",
-            toolSerialNumber: tool.serialNumber ?? "",
-            toolDescription: tool.description ?? "",
-            toolMake: tool.make ?? "",
-            toolVersion: tool.version ?? "",
-        }, true);
+        setAttributes(
+            {
+                toolLabel: tool.label ?? "",
+                toolSerialNumber: tool.serialNumber ?? "",
+                toolDescription: tool.description ?? "",
+                toolMake: tool.make ?? "",
+                toolVersion: tool.version ?? "",
+            },
+            true
+        );
     };
     return (
         <>

--- a/client/components/edit/datastream/DatastreamProcessMetadataTask.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataTask.tsx
@@ -3,100 +3,122 @@ import FormControl from "@mui/material/FormControl";
 import { ProcessMetadataTask } from "../../../context/ProcessMetadataContext";
 import BlurSavingTextField from "../../shared/BlurSavingTextField";
 import Grid from "@mui/material/Grid";
+import Delete from "@mui/icons-material/Delete";
+import AddCircle from "@mui/icons-material/AddCircle";
+import IconButton from "@mui/material/IconButton";
 
 interface DatastreamProcessMetadataTaskProps {
     task: ProcessMetadataTask;
+    deleteTask: () => void;
+    addBelow: () => void;
     setAttribute: (attribute: string, value: string) => void;
 }
 
 const DatastreamProcessMetadataTask = ({
     task,
+    deleteTask,
+    addBelow,
     setAttribute,
 }: DatastreamProcessMetadataTaskProps): React.ReactElement => {
     return (
-        <Grid container spacing={1} style={{ "margin-bottom": "10px" }}>
-            <Grid item xs={3}>
-                <FormControl fullWidth={true}>
-                    <BlurSavingTextField
-                        options={{ label: "Task Sequence" }}
-                        value={task.sequence ?? ""}
-                        setValue={(value) => setAttribute("sequence", value)}
-                    />
-                </FormControl>
+        <>
+            <hr style={{ marginBottom: "20px" }} />
+            <Grid container spacing={1}>
+                <Grid item xs={11}>
+                    <Grid container spacing={1} style={{ marginBottom: "10px" }}>
+                        <Grid item xs={3}>
+                            <FormControl fullWidth={true}>
+                                <BlurSavingTextField
+                                    options={{ label: "Task Sequence" }}
+                                    value={task.sequence ?? ""}
+                                    setValue={(value) => setAttribute("sequence", value)}
+                                />
+                            </FormControl>
+                        </Grid>
+                        <Grid item xs={3}>
+                            <FormControl fullWidth={true}>
+                                <BlurSavingTextField
+                                    options={{ label: "Task Label" }}
+                                    value={task.label ?? ""}
+                                    setValue={(value) => setAttribute("label", value)}
+                                />
+                            </FormControl>
+                        </Grid>
+                        <Grid item xs={3}>
+                            <FormControl fullWidth={true}>
+                                <BlurSavingTextField
+                                    options={{ label: "Task Description" }}
+                                    value={task.description ?? ""}
+                                    setValue={(value) => setAttribute("description", value)}
+                                />
+                            </FormControl>
+                        </Grid>
+                        <Grid item xs={3}>
+                            <FormControl fullWidth={true}>
+                                <BlurSavingTextField
+                                    options={{ label: "Task Individual" }}
+                                    value={task.individual ?? ""}
+                                    setValue={(value) => setAttribute("individual", value)}
+                                />
+                            </FormControl>
+                        </Grid>
+                        <Grid item xs={3}>
+                            <FormControl fullWidth={true}>
+                                <BlurSavingTextField
+                                    options={{ label: "Task Tool" }}
+                                    value={task.toolLabel ?? ""}
+                                    setValue={(value) => setAttribute("toolLabel", value)}
+                                />
+                            </FormControl>
+                        </Grid>
+                        <Grid item xs={3}>
+                            <FormControl fullWidth={true}>
+                                <BlurSavingTextField
+                                    options={{ label: "Tool Description" }}
+                                    value={task.toolDescription ?? ""}
+                                    setValue={(value) => setAttribute("toolDescription", value)}
+                                />
+                            </FormControl>
+                        </Grid>
+                        <Grid item xs={2}>
+                            <FormControl fullWidth={true}>
+                                <BlurSavingTextField
+                                    options={{ label: "Tool Make" }}
+                                    value={task.toolMake ?? ""}
+                                    setValue={(value) => setAttribute("toolMake", value)}
+                                />
+                            </FormControl>
+                        </Grid>
+                        <Grid item xs={2}>
+                            <FormControl fullWidth={true}>
+                                <BlurSavingTextField
+                                    options={{ label: "Tool Version" }}
+                                    value={task.toolVersion ?? ""}
+                                    setValue={(value) => setAttribute("toolVersion", value)}
+                                />
+                            </FormControl>
+                        </Grid>
+                        <Grid item xs={2}>
+                            <FormControl fullWidth={true}>
+                                <BlurSavingTextField
+                                    options={{ label: "Tool Serial Number" }}
+                                    value={task.toolSerialNumber ?? ""}
+                                    setValue={(value) => setAttribute("toolSerialNumber", value)}
+                                />
+                            </FormControl>
+                        </Grid>
+                    </Grid>
+                </Grid>
+                <Grid item xs={1}>
+                    <IconButton onClick={addBelow}>
+                        <AddCircle titleAccess="Add Below" />
+                    </IconButton>
+                    <IconButton onClick={deleteTask}>
+                        <Delete titleAccess="Delete Task" />
+                    </IconButton>
+                </Grid>
             </Grid>
-            <Grid item xs={3}>
-                <FormControl fullWidth={true}>
-                    <BlurSavingTextField
-                        options={{ label: "Task Label" }}
-                        value={task.label ?? ""}
-                        setValue={(value) => setAttribute("label", value)}
-                    />
-                </FormControl>
-            </Grid>
-            <Grid item xs={3}>
-                <FormControl fullWidth={true}>
-                    <BlurSavingTextField
-                        options={{ label: "Task Description" }}
-                        value={task.description ?? ""}
-                        setValue={(value) => setAttribute("description", value)}
-                    />
-                </FormControl>
-            </Grid>
-            <Grid item xs={3}>
-                <FormControl fullWidth={true}>
-                    <BlurSavingTextField
-                        options={{ label: "Task Individual" }}
-                        value={task.individual ?? ""}
-                        setValue={(value) => setAttribute("individual", value)}
-                    />
-                </FormControl>
-            </Grid>
-            <Grid item xs={3}>
-                <FormControl fullWidth={true}>
-                    <BlurSavingTextField
-                        options={{ label: "Task Tool" }}
-                        value={task.toolLabel ?? ""}
-                        setValue={(value) => setAttribute("toolLabel", value)}
-                    />
-                </FormControl>
-            </Grid>
-            <Grid item xs={3}>
-                <FormControl fullWidth={true}>
-                    <BlurSavingTextField
-                        options={{ label: "Tool Description" }}
-                        value={task.toolDescription ?? ""}
-                        setValue={(value) => setAttribute("toolDescription", value)}
-                    />
-                </FormControl>
-            </Grid>
-            <Grid item xs={2}>
-                <FormControl fullWidth={true}>
-                    <BlurSavingTextField
-                        options={{ label: "Tool Make" }}
-                        value={task.toolMake ?? ""}
-                        setValue={(value) => setAttribute("toolMake", value)}
-                    />
-                </FormControl>
-            </Grid>
-            <Grid item xs={2}>
-                <FormControl fullWidth={true}>
-                    <BlurSavingTextField
-                        options={{ label: "Tool Version" }}
-                        value={task.toolVersion ?? ""}
-                        setValue={(value) => setAttribute("toolVersion", value)}
-                    />
-                </FormControl>
-            </Grid>
-            <Grid item xs={2}>
-                <FormControl fullWidth={true}>
-                    <BlurSavingTextField
-                        options={{ label: "Tool Serial Number" }}
-                        value={task.toolSerialNumber ?? ""}
-                        setValue={(value) => setAttribute("toolSerialNumber", value)}
-                    />
-                </FormControl>
-            </Grid>
-        </Grid>
+        </>
     );
 };
 

--- a/client/components/edit/datastream/DatastreamProcessMetadataTask.tsx
+++ b/client/components/edit/datastream/DatastreamProcessMetadataTask.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import FormControl from "@mui/material/FormControl";
 import { ProcessMetadataTask } from "../../../context/ProcessMetadataContext";
 import BlurSavingTextField from "../../shared/BlurSavingTextField";
@@ -6,20 +6,37 @@ import Grid from "@mui/material/Grid";
 import Delete from "@mui/icons-material/Delete";
 import AddCircle from "@mui/icons-material/AddCircle";
 import IconButton from "@mui/material/IconButton";
+import { useEditorContext } from "../../../context/EditorContext";
+import NativeSelect from "@mui/material/NativeSelect";
 
 interface DatastreamProcessMetadataTaskProps {
     task: ProcessMetadataTask;
     deleteTask: () => void;
     addBelow: () => void;
-    setAttribute: (attribute: string, value: string) => void;
+    setAttributes: (attributes: Record<string, string>, forceNewGeneration?: boolean) => void;
 }
 
 const DatastreamProcessMetadataTask = ({
     task,
     deleteTask,
     addBelow,
-    setAttribute,
+    setAttributes,
 }: DatastreamProcessMetadataTaskProps): React.ReactElement => {
+    const {
+        state: { toolPresets },
+    } = useEditorContext();
+    const [selectedTool, setSelectedTool] = useState(Object.keys(toolPresets)[0] ?? "");
+    const applyToolPreset = () => {
+        const tool = toolPresets[selectedTool] ?? {};
+        // TODO: figure out why the second parameter (true) is necessary to trigger redraws
+        setAttributes({
+            toolLabel: tool.label ?? "",
+            toolSerialNumber: tool.serialNumber ?? "",
+            toolDescription: tool.description ?? "",
+            toolMake: tool.make ?? "",
+            toolVersion: tool.version ?? "",
+        }, true);
+    };
     return (
         <>
             <hr style={{ marginBottom: "20px" }} />
@@ -31,7 +48,7 @@ const DatastreamProcessMetadataTask = ({
                                 <BlurSavingTextField
                                     options={{ label: "Task Sequence" }}
                                     value={task.sequence ?? ""}
-                                    setValue={(value) => setAttribute("sequence", value)}
+                                    setValue={(value) => setAttributes({ sequence: value })}
                                 />
                             </FormControl>
                         </Grid>
@@ -40,7 +57,7 @@ const DatastreamProcessMetadataTask = ({
                                 <BlurSavingTextField
                                     options={{ label: "Task Label" }}
                                     value={task.label ?? ""}
-                                    setValue={(value) => setAttribute("label", value)}
+                                    setValue={(value) => setAttributes({ label: value })}
                                 />
                             </FormControl>
                         </Grid>
@@ -49,7 +66,7 @@ const DatastreamProcessMetadataTask = ({
                                 <BlurSavingTextField
                                     options={{ label: "Task Description" }}
                                     value={task.description ?? ""}
-                                    setValue={(value) => setAttribute("description", value)}
+                                    setValue={(value) => setAttributes({ description: value })}
                                 />
                             </FormControl>
                         </Grid>
@@ -58,16 +75,39 @@ const DatastreamProcessMetadataTask = ({
                                 <BlurSavingTextField
                                     options={{ label: "Task Individual" }}
                                     value={task.individual ?? ""}
-                                    setValue={(value) => setAttribute("individual", value)}
+                                    setValue={(value) => setAttributes({ individual: value })}
                                 />
                             </FormControl>
+                        </Grid>
+                        <Grid item xs={7}>
+                            <FormControl fullWidth={true}>
+                                <label>
+                                    Select a preset tool:
+                                    <NativeSelect
+                                        value={selectedTool}
+                                        onChange={(event) => setSelectedTool(event.target.value)}
+                                    >
+                                        {Object.keys(toolPresets).map((index: number) => {
+                                            const tool = toolPresets[index];
+                                            return (
+                                                <option key={`tool_preset_${index}`} value={index}>
+                                                    {tool.label ?? ""}
+                                                </option>
+                                            );
+                                        })}
+                                    </NativeSelect>
+                                </label>
+                            </FormControl>
+                        </Grid>
+                        <Grid item xs={5}>
+                            <button onClick={applyToolPreset}>Apply Preset</button>
                         </Grid>
                         <Grid item xs={3}>
                             <FormControl fullWidth={true}>
                                 <BlurSavingTextField
                                     options={{ label: "Task Tool" }}
                                     value={task.toolLabel ?? ""}
-                                    setValue={(value) => setAttribute("toolLabel", value)}
+                                    setValue={(value) => setAttributes({ toolLabel: value })}
                                 />
                             </FormControl>
                         </Grid>
@@ -76,7 +116,7 @@ const DatastreamProcessMetadataTask = ({
                                 <BlurSavingTextField
                                     options={{ label: "Tool Description" }}
                                     value={task.toolDescription ?? ""}
-                                    setValue={(value) => setAttribute("toolDescription", value)}
+                                    setValue={(value) => setAttributes({ toolDescription: value })}
                                 />
                             </FormControl>
                         </Grid>
@@ -85,7 +125,7 @@ const DatastreamProcessMetadataTask = ({
                                 <BlurSavingTextField
                                     options={{ label: "Tool Make" }}
                                     value={task.toolMake ?? ""}
-                                    setValue={(value) => setAttribute("toolMake", value)}
+                                    setValue={(value) => setAttributes({ toolMake: value })}
                                 />
                             </FormControl>
                         </Grid>
@@ -94,7 +134,7 @@ const DatastreamProcessMetadataTask = ({
                                 <BlurSavingTextField
                                     options={{ label: "Tool Version" }}
                                     value={task.toolVersion ?? ""}
-                                    setValue={(value) => setAttribute("toolVersion", value)}
+                                    setValue={(value) => setAttributes({ toolVersion: value })}
                                 />
                             </FormControl>
                         </Grid>
@@ -103,7 +143,7 @@ const DatastreamProcessMetadataTask = ({
                                 <BlurSavingTextField
                                     options={{ label: "Tool Serial Number" }}
                                     value={task.toolSerialNumber ?? ""}
-                                    setValue={(value) => setAttribute("toolSerialNumber", value)}
+                                    setValue={(value) => setAttributes({ toolSerialNumber: value })}
                                 />
                             </FormControl>
                         </Grid>

--- a/client/components/edit/datastream/DatastreamUploadModalContent.tsx
+++ b/client/components/edit/datastream/DatastreamUploadModalContent.tsx
@@ -4,11 +4,13 @@ import DatastreamAgentsContent from "./DatastreamAgentsContent";
 import DatastreamLicenseContent from "./DatastreamLicenseContent";
 import DatastreamUploadContent from "./DatastreamUploadContent";
 import DatastreamDublinCoreContent from "./DatastreamDublinCoreContent";
+import DatastreamProcessMetadataContent from "./DatastreamProcessMetadataContent";
 
 const uploadModalMapping = {
     LICENSE: <DatastreamLicenseContent />,
     AGENTS: <DatastreamAgentsContent />,
     DC: <DatastreamDublinCoreContent />,
+    "PROCESS-MD": <DatastreamProcessMetadataContent />,
 };
 
 const DatastreamUploadModalContent = (): React.ReactElement => {

--- a/client/components/edit/datastream/DatastreamUploadModalContent.tsx
+++ b/client/components/edit/datastream/DatastreamUploadModalContent.tsx
@@ -5,12 +5,17 @@ import DatastreamLicenseContent from "./DatastreamLicenseContent";
 import DatastreamUploadContent from "./DatastreamUploadContent";
 import DatastreamDublinCoreContent from "./DatastreamDublinCoreContent";
 import DatastreamProcessMetadataContent from "./DatastreamProcessMetadataContent";
+import { ProcessMetadataContextProvider } from "../../../context/ProcessMetadataContext";
 
-const uploadModalMapping = {
+const uploadModalMapping: Record<string, React.ReactElement> = {
     LICENSE: <DatastreamLicenseContent />,
     AGENTS: <DatastreamAgentsContent />,
     DC: <DatastreamDublinCoreContent />,
-    "PROCESS-MD": <DatastreamProcessMetadataContent />,
+    "PROCESS-MD": (
+        <ProcessMetadataContextProvider>
+            <DatastreamProcessMetadataContent />
+        </ProcessMetadataContextProvider>
+    ),
 };
 
 const DatastreamUploadModalContent = (): React.ReactElement => {

--- a/client/components/edit/datastream/__snapshots__/DatastreamProcessMetadataContent.test.tsx.snap
+++ b/client/components/edit/datastream/__snapshots__/DatastreamProcessMetadataContent.test.tsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DatastreamProcessMetadataContent renders a loading message if content is unavailable 1`] = `
+<ForwardRef(DialogContent)>
+  Loading...
+</ForwardRef(DialogContent)>
+`;

--- a/client/components/edit/datastream/__snapshots__/DatastreamProcessMetadataTask.test.tsx.snap
+++ b/client/components/edit/datastream/__snapshots__/DatastreamProcessMetadataTask.test.tsx.snap
@@ -1,0 +1,460 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DatastreamProcessMetadataTask renders with tool presets 1`] = `
+<Fragment>
+  <hr
+    style={
+      Object {
+        "marginBottom": "20px",
+      }
+    }
+  />
+  <ForwardRef(Grid)
+    container={true}
+    spacing={1}
+  >
+    <ForwardRef(Grid)
+      item={true}
+      xs={11}
+    >
+      <ForwardRef(Grid)
+        container={true}
+        spacing={1}
+        style={
+          Object {
+            "marginBottom": "10px",
+          }
+        }
+      >
+        <ForwardRef(Grid)
+          item={true}
+          xs={3}
+        >
+          <ForwardRef(FormControl)
+            fullWidth={true}
+          >
+            <BlurSavingTextField
+              options={
+                Object {
+                  "label": "Task Sequence",
+                }
+              }
+              setValue={[Function]}
+              value="seq"
+            />
+          </ForwardRef(FormControl)>
+        </ForwardRef(Grid)>
+        <ForwardRef(Grid)
+          item={true}
+          xs={3}
+        >
+          <ForwardRef(FormControl)
+            fullWidth={true}
+          >
+            <BlurSavingTextField
+              options={
+                Object {
+                  "label": "Task Label",
+                }
+              }
+              setValue={[Function]}
+              value="lab"
+            />
+          </ForwardRef(FormControl)>
+        </ForwardRef(Grid)>
+        <ForwardRef(Grid)
+          item={true}
+          xs={3}
+        >
+          <ForwardRef(FormControl)
+            fullWidth={true}
+          >
+            <BlurSavingTextField
+              options={
+                Object {
+                  "label": "Task Description",
+                }
+              }
+              setValue={[Function]}
+              value="des"
+            />
+          </ForwardRef(FormControl)>
+        </ForwardRef(Grid)>
+        <ForwardRef(Grid)
+          item={true}
+          xs={3}
+        >
+          <ForwardRef(FormControl)
+            fullWidth={true}
+          >
+            <BlurSavingTextField
+              options={
+                Object {
+                  "label": "Task Individual",
+                }
+              }
+              setValue={[Function]}
+              value="ind"
+            />
+          </ForwardRef(FormControl)>
+        </ForwardRef(Grid)>
+        <ForwardRef(Grid)
+          item={true}
+          xs={7}
+        >
+          <ForwardRef(FormControl)
+            fullWidth={true}
+          >
+            <label>
+              Select a preset tool:
+              <ForwardRef(NativeSelect)
+                onChange={[Function]}
+                value="0"
+              >
+                <option
+                  key="tool_preset_0"
+                  value="0"
+                >
+                  My Tool
+                </option>
+              </ForwardRef(NativeSelect)>
+            </label>
+          </ForwardRef(FormControl)>
+        </ForwardRef(Grid)>
+        <ForwardRef(Grid)
+          item={true}
+          xs={5}
+        >
+          <button
+            onClick={[Function]}
+          >
+            Apply Preset
+          </button>
+        </ForwardRef(Grid)>
+        <ForwardRef(Grid)
+          item={true}
+          xs={3}
+        >
+          <ForwardRef(FormControl)
+            fullWidth={true}
+          >
+            <BlurSavingTextField
+              options={
+                Object {
+                  "label": "Task Tool",
+                }
+              }
+              setValue={[Function]}
+              value="tool-lab"
+            />
+          </ForwardRef(FormControl)>
+        </ForwardRef(Grid)>
+        <ForwardRef(Grid)
+          item={true}
+          xs={3}
+        >
+          <ForwardRef(FormControl)
+            fullWidth={true}
+          >
+            <BlurSavingTextField
+              options={
+                Object {
+                  "label": "Tool Description",
+                }
+              }
+              setValue={[Function]}
+              value="tool-des"
+            />
+          </ForwardRef(FormControl)>
+        </ForwardRef(Grid)>
+        <ForwardRef(Grid)
+          item={true}
+          xs={2}
+        >
+          <ForwardRef(FormControl)
+            fullWidth={true}
+          >
+            <BlurSavingTextField
+              options={
+                Object {
+                  "label": "Tool Make",
+                }
+              }
+              setValue={[Function]}
+              value="tool-mak"
+            />
+          </ForwardRef(FormControl)>
+        </ForwardRef(Grid)>
+        <ForwardRef(Grid)
+          item={true}
+          xs={2}
+        >
+          <ForwardRef(FormControl)
+            fullWidth={true}
+          >
+            <BlurSavingTextField
+              options={
+                Object {
+                  "label": "Tool Version",
+                }
+              }
+              setValue={[Function]}
+              value="tool-ver"
+            />
+          </ForwardRef(FormControl)>
+        </ForwardRef(Grid)>
+        <ForwardRef(Grid)
+          item={true}
+          xs={2}
+        >
+          <ForwardRef(FormControl)
+            fullWidth={true}
+          >
+            <BlurSavingTextField
+              options={
+                Object {
+                  "label": "Tool Serial Number",
+                }
+              }
+              setValue={[Function]}
+              value="tool-ser"
+            />
+          </ForwardRef(FormControl)>
+        </ForwardRef(Grid)>
+      </ForwardRef(Grid)>
+    </ForwardRef(Grid)>
+    <ForwardRef(Grid)
+      item={true}
+      xs={1}
+    >
+      <ForwardRef(IconButton)
+        onClick={[MockFunction]}
+      >
+        <Memo(ForwardRef(AddCircleIcon))
+          titleAccess="Add Below"
+        />
+      </ForwardRef(IconButton)>
+      <ForwardRef(IconButton)
+        onClick={[MockFunction]}
+      >
+        <Memo(ForwardRef(DeleteIcon))
+          titleAccess="Delete Task"
+        />
+      </ForwardRef(IconButton)>
+    </ForwardRef(Grid)>
+  </ForwardRef(Grid)>
+</Fragment>
+`;
+
+exports[`DatastreamProcessMetadataTask renders without tool presets 1`] = `
+<Fragment>
+  <hr
+    style={
+      Object {
+        "marginBottom": "20px",
+      }
+    }
+  />
+  <ForwardRef(Grid)
+    container={true}
+    spacing={1}
+  >
+    <ForwardRef(Grid)
+      item={true}
+      xs={11}
+    >
+      <ForwardRef(Grid)
+        container={true}
+        spacing={1}
+        style={
+          Object {
+            "marginBottom": "10px",
+          }
+        }
+      >
+        <ForwardRef(Grid)
+          item={true}
+          xs={3}
+        >
+          <ForwardRef(FormControl)
+            fullWidth={true}
+          >
+            <BlurSavingTextField
+              options={
+                Object {
+                  "label": "Task Sequence",
+                }
+              }
+              setValue={[Function]}
+              value="seq"
+            />
+          </ForwardRef(FormControl)>
+        </ForwardRef(Grid)>
+        <ForwardRef(Grid)
+          item={true}
+          xs={3}
+        >
+          <ForwardRef(FormControl)
+            fullWidth={true}
+          >
+            <BlurSavingTextField
+              options={
+                Object {
+                  "label": "Task Label",
+                }
+              }
+              setValue={[Function]}
+              value="lab"
+            />
+          </ForwardRef(FormControl)>
+        </ForwardRef(Grid)>
+        <ForwardRef(Grid)
+          item={true}
+          xs={3}
+        >
+          <ForwardRef(FormControl)
+            fullWidth={true}
+          >
+            <BlurSavingTextField
+              options={
+                Object {
+                  "label": "Task Description",
+                }
+              }
+              setValue={[Function]}
+              value="des"
+            />
+          </ForwardRef(FormControl)>
+        </ForwardRef(Grid)>
+        <ForwardRef(Grid)
+          item={true}
+          xs={3}
+        >
+          <ForwardRef(FormControl)
+            fullWidth={true}
+          >
+            <BlurSavingTextField
+              options={
+                Object {
+                  "label": "Task Individual",
+                }
+              }
+              setValue={[Function]}
+              value="ind"
+            />
+          </ForwardRef(FormControl)>
+        </ForwardRef(Grid)>
+        <ForwardRef(Grid)
+          item={true}
+          xs={3}
+        >
+          <ForwardRef(FormControl)
+            fullWidth={true}
+          >
+            <BlurSavingTextField
+              options={
+                Object {
+                  "label": "Task Tool",
+                }
+              }
+              setValue={[Function]}
+              value="tool-lab"
+            />
+          </ForwardRef(FormControl)>
+        </ForwardRef(Grid)>
+        <ForwardRef(Grid)
+          item={true}
+          xs={3}
+        >
+          <ForwardRef(FormControl)
+            fullWidth={true}
+          >
+            <BlurSavingTextField
+              options={
+                Object {
+                  "label": "Tool Description",
+                }
+              }
+              setValue={[Function]}
+              value="tool-des"
+            />
+          </ForwardRef(FormControl)>
+        </ForwardRef(Grid)>
+        <ForwardRef(Grid)
+          item={true}
+          xs={2}
+        >
+          <ForwardRef(FormControl)
+            fullWidth={true}
+          >
+            <BlurSavingTextField
+              options={
+                Object {
+                  "label": "Tool Make",
+                }
+              }
+              setValue={[Function]}
+              value="tool-mak"
+            />
+          </ForwardRef(FormControl)>
+        </ForwardRef(Grid)>
+        <ForwardRef(Grid)
+          item={true}
+          xs={2}
+        >
+          <ForwardRef(FormControl)
+            fullWidth={true}
+          >
+            <BlurSavingTextField
+              options={
+                Object {
+                  "label": "Tool Version",
+                }
+              }
+              setValue={[Function]}
+              value="tool-ver"
+            />
+          </ForwardRef(FormControl)>
+        </ForwardRef(Grid)>
+        <ForwardRef(Grid)
+          item={true}
+          xs={2}
+        >
+          <ForwardRef(FormControl)
+            fullWidth={true}
+          >
+            <BlurSavingTextField
+              options={
+                Object {
+                  "label": "Tool Serial Number",
+                }
+              }
+              setValue={[Function]}
+              value="tool-ser"
+            />
+          </ForwardRef(FormControl)>
+        </ForwardRef(Grid)>
+      </ForwardRef(Grid)>
+    </ForwardRef(Grid)>
+    <ForwardRef(Grid)
+      item={true}
+      xs={1}
+    >
+      <ForwardRef(IconButton)
+        onClick={[MockFunction]}
+      >
+        <Memo(ForwardRef(AddCircleIcon))
+          titleAccess="Add Below"
+        />
+      </ForwardRef(IconButton)>
+      <ForwardRef(IconButton)
+        onClick={[MockFunction]}
+      >
+        <Memo(ForwardRef(DeleteIcon))
+          titleAccess="Delete Task"
+        />
+      </ForwardRef(IconButton)>
+    </ForwardRef(Grid)>
+  </ForwardRef(Grid)>
+</Fragment>
+`;

--- a/client/context/EditorContext.tsx
+++ b/client/context/EditorContext.tsx
@@ -47,6 +47,7 @@ interface EditorState {
     agentsCatalog: Record<string, Object>;
     dublinCoreFieldCatalog: Record<string, Record<string, string>>;
     favoritePidsCatalog: Record<string, string>;
+    processMetadataDefaults: Record<string, string>;
     toolPresets: Array<Record<string, string>>;
     vufindUrl: string;
     currentAgents: Array<Object>;
@@ -75,6 +76,7 @@ const editorContextParams: EditorState = {
     agentsCatalog: {},
     dublinCoreFieldCatalog: {},
     favoritePidsCatalog: {},
+    processMetadataDefaults: {},
     toolPresets: [],
     vufindUrl: "",
     currentAgents: [],
@@ -112,6 +114,7 @@ const reducerMapping: Record<string, string> = {
     SET_AGENTS_CATALOG: "agentsCatalog",
     SET_DUBLIN_CORE_FIELD_CATALOG: "dublinCoreFieldCatalog",
     SET_FAVORITE_PIDS_CATALOG: "favoritePidsCatalog",
+    SET_PROCESS_METADATA_DEFAULTS: "processMetadataDefaults",
     SET_TOOL_PRESETS: "toolPresets",
     SET_VUFIND_URL: "vufindUrl",
     SET_LICENSES_CATALOG: "licensesCatalog",
@@ -233,6 +236,7 @@ export const useEditorContext = () => {
             agentsCatalog,
             dublinCoreFieldCatalog,
             favoritePidsCatalog,
+            processMetadataDefaults,
             toolPresets,
             vufindUrl,
             licensesCatalog,
@@ -383,6 +387,13 @@ export const useEditorContext = () => {
         });
     }
 
+    const setProcessMetadataDefaults = (defaults: Record<string, string>) => {
+        dispatch({
+            type: "SET_PROCESS_METADATA_DEFAULTS",
+            payload: defaults
+        });
+    }
+
     const setToolPresets = (toolPresets: Array<Record<string, string>>) => {
         dispatch({
             type: "SET_TOOL_PRESETS",
@@ -488,6 +499,7 @@ export const useEditorContext = () => {
             setLicensesCatalog(response.licenses || {});
             setFavoritePidsCatalog(response.favoritePids || {});
             setToolPresets(response.toolPresets || []);
+            setProcessMetadataDefaults(response.processMetadataDefaults || {});
             setAgentsCatalog(response.agents || {});
             setDublinCoreFieldCatalog(response.dublinCoreFields || {});
             setVuFindUrl(response.vufindUrl ?? "");
@@ -523,6 +535,7 @@ export const useEditorContext = () => {
             agentsCatalog,
             dublinCoreFieldCatalog,
             favoritePidsCatalog,
+            processMetadataDefaults,
             toolPresets,
             vufindUrl,
             modelsCatalog,

--- a/client/context/EditorContext.tsx
+++ b/client/context/EditorContext.tsx
@@ -47,6 +47,7 @@ interface EditorState {
     agentsCatalog: Record<string, Object>;
     dublinCoreFieldCatalog: Record<string, Record<string, string>>;
     favoritePidsCatalog: Record<string, string>;
+    toolPresets: Array<Record<string, string>>;
     vufindUrl: string;
     currentAgents: Array<Object>;
     currentDublinCore: Record<string, Array<string>>;
@@ -74,6 +75,7 @@ const editorContextParams: EditorState = {
     agentsCatalog: {},
     dublinCoreFieldCatalog: {},
     favoritePidsCatalog: {},
+    toolPresets: [],
     vufindUrl: "",
     currentAgents: [],
     currentDublinCore: {},
@@ -110,6 +112,7 @@ const reducerMapping: Record<string, string> = {
     SET_AGENTS_CATALOG: "agentsCatalog",
     SET_DUBLIN_CORE_FIELD_CATALOG: "dublinCoreFieldCatalog",
     SET_FAVORITE_PIDS_CATALOG: "favoritePidsCatalog",
+    SET_TOOL_PRESETS: "toolPresets",
     SET_VUFIND_URL: "vufindUrl",
     SET_LICENSES_CATALOG: "licensesCatalog",
     SET_MODELS_CATALOG: "modelsCatalog",
@@ -230,6 +233,7 @@ export const useEditorContext = () => {
             agentsCatalog,
             dublinCoreFieldCatalog,
             favoritePidsCatalog,
+            toolPresets,
             vufindUrl,
             licensesCatalog,
             modelsCatalog,
@@ -379,6 +383,13 @@ export const useEditorContext = () => {
         });
     }
 
+    const setToolPresets = (toolPresets: Array<Record<string, string>>) => {
+        dispatch({
+            type: "SET_TOOL_PRESETS",
+            payload: toolPresets
+        });
+    }
+
     const setVuFindUrl = (url: string) => {
         dispatch({
             type: "SET_VUFIND_URL",
@@ -476,6 +487,7 @@ export const useEditorContext = () => {
             setModelsCatalog(response.models || {});
             setLicensesCatalog(response.licenses || {});
             setFavoritePidsCatalog(response.favoritePids || {});
+            setToolPresets(response.toolPresets || []);
             setAgentsCatalog(response.agents || {});
             setDublinCoreFieldCatalog(response.dublinCoreFields || {});
             setVuFindUrl(response.vufindUrl ?? "");
@@ -511,6 +523,7 @@ export const useEditorContext = () => {
             agentsCatalog,
             dublinCoreFieldCatalog,
             favoritePidsCatalog,
+            toolPresets,
             vufindUrl,
             modelsCatalog,
             licensesCatalog,

--- a/client/context/ProcessMetadataContext.test.tsx
+++ b/client/context/ProcessMetadataContext.test.tsx
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { renderHook, act } from "@testing-library/react-hooks";
+import { ProcessMetadataContextProvider, useProcessMetadataContext } from "./ProcessMetadataContext";
+
+describe("useProcessMetadataContext", () => {
+    it("allows task manipulation", async () => {
+        const { result } = await renderHook(() => useProcessMetadataContext(), { wrapper: ProcessMetadataContextProvider });
+        act(() => {
+            result.current.action.addTask(0);
+            result.current.action.updateTaskAttributes(0, { label: "foo", toolLabel: "bar" });
+            result.current.action.addTask(1);   // add at end
+            result.current.action.addTask(0);   // add at top, push others down
+            result.current.action.updateTaskAttribute(0, "sequence", "first");
+            result.current.action.updateTaskAttribute(2, "sequence", "last");
+        });
+        expect(result.current.state.tasks).toEqual([
+            {
+                "description": "",
+                "id": "1",
+                "individual": "",
+                "label": "",
+                "sequence": "first",
+                "toolDescription": "",
+                "toolLabel": "",
+                "toolMake": "",
+                "toolSerialNumber": "",
+                "toolVersion": "",
+              },
+              {
+                "description": "",
+                "id": "2",
+                "individual": "",
+                "label": "foo",
+                "sequence": "1",
+                "toolDescription": "",
+                "toolLabel": "bar",
+                "toolMake": "",
+                "toolSerialNumber": "",
+                "toolVersion": "",
+              },
+              {
+                "description": "",
+                "id": "3",
+                "individual": "",
+                "label": "",
+                "sequence": "last",
+                "toolDescription": "",
+                "toolLabel": "",
+                "toolMake": "",
+                "toolSerialNumber": "",
+                "toolVersion": "",
+              },              
+        ]);
+        act(() => {
+            result.current.action.deleteTask(1);
+        })
+        expect(result.current.state.tasks).toEqual([
+            {
+                "description": "",
+                "id": "1",
+                "individual": "",
+                "label": "",
+                "sequence": "first",
+                "toolDescription": "",
+                "toolLabel": "",
+                "toolMake": "",
+                "toolSerialNumber": "",
+                "toolVersion": "",
+              },
+              {
+                "description": "",
+                "id": "2",
+                "individual": "",
+                "label": "",
+                "sequence": "last",
+                "toolDescription": "",
+                "toolLabel": "",
+                "toolMake": "",
+                "toolSerialNumber": "",
+                "toolVersion": "",
+              },              
+        ]);
+    });
+
+    it("allows setting of top-level metadata", async () => {
+        const { result } = await renderHook(() => useProcessMetadataContext(), { wrapper: ProcessMetadataContextProvider });
+        act(() => {
+            result.current.action.setProcessCreator("foo");
+            result.current.action.setProcessDateTime ("bar");
+            result.current.action.setProcessLabel("baz");
+            result.current.action.setProcessOrganization("xyzzy");
+        })
+        expect(result.current.state).toEqual({
+            "processCreator": "foo",
+            "processDateTime": "bar",
+            "processLabel": "baz",
+            "processOrganization": "xyzzy",
+        });
+    });
+
+    describe("setMetadata", () => {
+        it("sets the current metadata", async () => {
+            const metadata = { processLabel: "test" };
+            const { result } = await renderHook(() => useProcessMetadataContext(), { wrapper: ProcessMetadataContextProvider });
+
+            expect(result.current.state).not.toEqual(metadata);
+
+            act(() => {
+                result.current.action.setMetadata(metadata);
+            });
+
+            expect(result.current.state).toEqual(metadata);
+        });
+    });
+});

--- a/client/context/ProcessMetadataContext.tsx
+++ b/client/context/ProcessMetadataContext.tsx
@@ -1,0 +1,112 @@
+import React, { createContext, useContext, useReducer } from "react";
+import PropTypes from "prop-types";
+
+const ProcessMetadataContext = createContext({});
+
+export interface ProcessMetadataTask {
+    description?: string;
+    id?: string;
+    individual?: string;
+    label?: string;
+    sequence?: string;
+    toolDescription?: string;
+    toolLabel?: string;
+    toolMake?: string;
+    toolSerialNumber?: string;
+    toolVersion?: string;
+}
+
+export interface ProcessMetadata {
+    processCreator?: string;
+    processDateTime?: string;
+    processLabel?: string;
+    processOrganization?: string;
+    tasks?: Array<ProcessMetadataTask>;
+}
+
+/**
+ * Update the shared states of react components.
+ */
+const reducerMapping: Record<string, string> = {
+    UPDATE_PROCESS_CREATOR: "processCreator",
+    UPDATE_PROCESS_DATE_TIME: "processDateTime",
+    UPDATE_PROCESS_LABEL: "processLabel",
+    UPDATE_PROCESS_ORGANIZATION: "processOrganization",
+};
+const processMetadataReducer = (state, { type, payload }) => {
+    if (type === "UPDATE_METADATA") {
+        return payload;
+    } else if(Object.keys(reducerMapping).includes(type)) {
+        return {
+            ...state,
+            [reducerMapping[type]]: payload
+        };
+    }
+    console.error(`processMetadata action type: ${type} does not exist`);
+    return state;
+};
+
+export const ProcessMetadataContextProvider = ({ children }) => {
+    const [state, dispatch] = useReducer(processMetadataReducer, {});
+    const value = { state, dispatch };
+    return <ProcessMetadataContext.Provider value={value}>{children}</ProcessMetadataContext.Provider>;
+};
+
+export const useProcessMetadataContext = () => {
+    const {
+        state,
+        dispatch,
+    } = useContext(ProcessMetadataContext) as { state: ProcessMetadata, dispatch: (params: unknown) => void };
+
+    const setMetadata = (metadata: ProcessMetadata): void => {
+        dispatch({
+            type: "UPDATE_METADATA",
+            payload: metadata
+        });
+    };
+
+    const setProcessCreator = (value: string): void => {
+        dispatch({
+            type: "UPDATE_PROCESS_CREATOR",
+            payload: value
+        });
+    };
+
+    const setProcessDateTime = (value: string): void => {
+        dispatch({
+            type: "UPDATE_PROCESS_DATE_TIME",
+            payload: value
+        });
+    };
+
+    const setProcessLabel = (value: string): void => {
+        dispatch({
+            type: "UPDATE_PROCESS_LABEL",
+            payload: value
+        });
+    };
+
+    const setProcessOrganization = (value: string): void => {
+        dispatch({
+            type: "UPDATE_PROCESS_ORGANIZATION",
+            payload: value
+        });
+    };
+
+    return {
+        state,
+        action: {
+            setMetadata,
+            setProcessCreator,
+            setProcessDateTime,
+            setProcessLabel,
+            setProcessOrganization,
+        },
+    };
+};
+
+ProcessMetadataContextProvider.propTypes = {
+    children: PropTypes.node,
+};
+
+export default { ProcessMetadataContextProvider, useProcessMetadataContext };

--- a/client/context/ProcessMetadataContext.tsx
+++ b/client/context/ProcessMetadataContext.tsx
@@ -43,6 +43,21 @@ const resynchronizeTaskIds = (tasks: Array<ProcessMetadataTask>): Array<ProcessM
 const processMetadataReducer = (state: ProcessMetadata, { type, payload }: { type: string, payload: unknown }) => {
     if (type === "UPDATE_METADATA") {
         return payload;
+    } else if (type === "UPDATE_TASK_ATTRIBUTE") {
+        const { index, attribute, value } = payload as { index: number, attribute: string, value: string};
+        const tasks = (state.tasks ?? []).map((task, i) => {
+            if (i === index) {
+                return {
+                    ...task,
+                    [attribute]: value
+                };
+            }
+            return task;
+        });
+        return {
+            ...state,
+            tasks
+        };
     } else if (type === "ADD_TASK") {
         const index = payload as number;
         const newTask = {
@@ -105,6 +120,13 @@ export const useProcessMetadataContext = () => {
         });
     }
 
+    const updateTaskAttribute = (index: number, attribute: string, value: string): void => {
+        dispatch({
+            type: "UPDATE_TASK_ATTRIBUTE",
+            payload: { index, attribute, value }
+        });
+    }
+
     const setMetadata = (metadata: ProcessMetadata): void => {
         dispatch({
             type: "UPDATE_METADATA",
@@ -145,6 +167,7 @@ export const useProcessMetadataContext = () => {
         action: {
             addTask,
             deleteTask,
+            updateTaskAttribute,
             setMetadata,
             setProcessCreator,
             setProcessDateTime,

--- a/client/context/ProcessMetadataContext.tsx
+++ b/client/context/ProcessMetadataContext.tsx
@@ -43,13 +43,13 @@ const resynchronizeTaskIds = (tasks: Array<ProcessMetadataTask>): Array<ProcessM
 const processMetadataReducer = (state: ProcessMetadata, { type, payload }: { type: string, payload: unknown }) => {
     if (type === "UPDATE_METADATA") {
         return payload;
-    } else if (type === "UPDATE_TASK_ATTRIBUTE") {
-        const { index, attribute, value } = payload as { index: number, attribute: string, value: string};
+    } else if (type === "UPDATE_TASK_ATTRIBUTES") {
+        const { index, attributes } = payload as { index: number, attributes: Record<string, string>};
         const tasks = (state.tasks ?? []).map((task, i) => {
             if (i === index) {
                 return {
                     ...task,
-                    [attribute]: value
+                    ...attributes,
                 };
             }
             return task;
@@ -121,9 +121,13 @@ export const useProcessMetadataContext = () => {
     }
 
     const updateTaskAttribute = (index: number, attribute: string, value: string): void => {
+        updateTaskAttributes(index, { [attribute]: value });
+    }
+
+    const updateTaskAttributes = (index: number, attributes: Record<string, string>): void => {
         dispatch({
-            type: "UPDATE_TASK_ATTRIBUTE",
-            payload: { index, attribute, value }
+            type: "UPDATE_TASK_ATTRIBUTES",
+            payload: { index, attributes }
         });
     }
 
@@ -168,6 +172,7 @@ export const useProcessMetadataContext = () => {
             addTask,
             deleteTask,
             updateTaskAttribute,
+            updateTaskAttributes,
             setMetadata,
             setProcessCreator,
             setProcessDateTime,

--- a/client/context/ProcessMetadataContext.tsx
+++ b/client/context/ProcessMetadataContext.tsx
@@ -141,10 +141,10 @@ export const useProcessMetadataContext = () => {
         });
     };
 
-    const setProcessDateTime = (value: string): void => {
+    const setProcessDateTime = (value: string | null): void => {
         dispatch({
             type: "UPDATE_PROCESS_DATE_TIME",
-            payload: value
+            payload: value ?? ""
         });
     };
 

--- a/client/hooks/useDatastreamOperation.ts
+++ b/client/hooks/useDatastreamOperation.ts
@@ -132,6 +132,10 @@ const useDatastreamOperation = () => {
         toggleDatastreamModal();
     };
 
+    const uploadProcessMetadata = async (metadata) => {
+        // TODO
+    };
+
     const deleteDatastream = async () => {
         try {
             const text = await fetchText(deleteObjectDatastreamUrl(currentPid, activeDatastream), {
@@ -245,6 +249,10 @@ const useDatastreamOperation = () => {
         }
         return  "";
     };
+    const getProcessMetadata = async (): Promise<Array<object>> => {
+        // TODO
+        return  [];
+    };
     const getAgents = async (): Promise<Array<object>> => {
         if(currentDatastreams.includes(activeDatastream)) {
             try {
@@ -264,12 +272,14 @@ const useDatastreamOperation = () => {
         uploadDublinCore,
         uploadFile,
         uploadLicense,
+        uploadProcessMetadata,
         deleteDatastream,
         downloadDatastream,
         viewDatastream,
         viewMetadata,
         getDatastreamMimetype,
         getLicenseKey,
+        getProcessMetadata,
         getAgents
     };
 };

--- a/client/hooks/useDatastreamOperation.ts
+++ b/client/hooks/useDatastreamOperation.ts
@@ -18,7 +18,7 @@ const useDatastreamOperation = () => {
         action: { fetchBlob, fetchJSON, fetchText },
     } = useFetchContext();
     const {
-        state: { currentPid, activeDatastream, datastreamsCatalog, currentDatastreams },
+        state: { currentPid, activeDatastream, datastreamsCatalog, currentDatastreams, processMetadataDefaults },
         action: { setSnackbarState, toggleDatastreamModal, loadCurrentObjectDetails },
     } = useEditorContext();
 
@@ -282,7 +282,7 @@ const useDatastreamOperation = () => {
                 });
             }
         }
-        return {};
+        return processMetadataDefaults;
     };
     const getAgents = async (): Promise<Array<object>> => {
         if(currentDatastreams.includes(activeDatastream)) {

--- a/client/hooks/useDatastreamOperation.ts
+++ b/client/hooks/useDatastreamOperation.ts
@@ -133,8 +133,28 @@ const useDatastreamOperation = () => {
         toggleDatastreamModal();
     };
 
-    const uploadProcessMetadata = async (metadata) => {
-        // TODO
+    const uploadProcessMetadata = async (processMetadata) => {
+        try {
+            const text = await fetchText(objectDatastreamProcessMetadataUrl(currentPid, activeDatastream), {
+                method: "POST",
+                body: JSON.stringify({
+                    processMetadata
+                })
+            }, { "Content-Type": "application/json" });
+            await loadCurrentObjectDetails();
+            setSnackbarState({
+                open: true,
+                message: text,
+                severity: "success",
+            });
+        } catch (err) {
+            setSnackbarState({
+                open: true,
+                message: err.message,
+                severity: "error",
+            });
+        }
+        toggleDatastreamModal();
     };
 
     const deleteDatastream = async () => {

--- a/client/hooks/useDatastreamOperation.ts
+++ b/client/hooks/useDatastreamOperation.ts
@@ -9,7 +9,8 @@ import {
     viewObjectDatastreamUrl,
     getObjectDatastreamMetadataUrl,
     objectDatastreamAgentsUrl,
-    objectDatastreamDublinCoreUrl
+    objectDatastreamDublinCoreUrl,
+    objectDatastreamProcessMetadataUrl
  } from "../util/routes";
 
 const useDatastreamOperation = () => {
@@ -249,9 +250,19 @@ const useDatastreamOperation = () => {
         }
         return  "";
     };
-    const getProcessMetadata = async (): Promise<Array<object>> => {
-        // TODO
-        return  [];
+    const getProcessMetadata = async (): Promise<object> => {
+        if(currentDatastreams.includes(activeDatastream)) {
+            try {
+                return await fetchJSON(objectDatastreamProcessMetadataUrl(currentPid, activeDatastream));
+            } catch(err) {
+                setSnackbarState({
+                    open: true,
+                    message: err.message,
+                    severity: "error",
+                });
+            }
+        }
+        return {};
     };
     const getAgents = async (): Promise<Array<object>> => {
         if(currentDatastreams.includes(activeDatastream)) {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7,12 +7,15 @@
       "name": "client",
       "hasInstallScript": true,
       "dependencies": {
+        "@date-io/dayjs": "^2.16.0",
         "@emotion/styled": "^11.8.1",
         "@fortawesome/fontawesome-free": "^5.15.4",
         "@mui/icons-material": "^5.4.1",
         "@mui/lab": "^5.0.0-alpha.73",
         "@mui/material": "^5.3.0",
+        "@mui/x-date-pickers": "^5.0.7",
         "@tinymce/tinymce-react": "^4.2.0",
+        "dayjs": "^1.11.6",
         "html-react-parser": "^1.4.6",
         "identity-obj-proxy": "^3.0.0",
         "next": "12.1.5",
@@ -456,11 +459,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
-      "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
+      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.10"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -531,16 +534,16 @@
       "dev": true
     },
     "node_modules/@date-io/core": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/@date-io/core/-/core-2.13.2.tgz",
-      "integrity": "sha512-lAUDhC5kpzlxa00BxfqENBgerbGI5ojuKQpXLGZCTrqT1rQR+vrp2rwf0I+H2KlM2z3N1ldyQuANmzZ+ehomog=="
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@date-io/core/-/core-2.16.0.tgz",
+      "integrity": "sha512-DYmSzkr+jToahwWrsiRA2/pzMEtz9Bq1euJwoOuYwuwIYXnZFtHajY2E6a1VNVDc9jP8YUXK1BvnZH9mmT19Zg=="
     },
     "node_modules/@date-io/date-fns": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-2.13.2.tgz",
-      "integrity": "sha512-Pq0xBH6cvEg5IsOs7Olkk1PHFFJFTM34OT5mk/9ND1ied4RGhLNeLYRwbyCThZ29jolqPsV2HBs9wo2QTiNIkg==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-2.16.0.tgz",
+      "integrity": "sha512-bfm5FJjucqlrnQcXDVU5RD+nlGmL3iWgkHTq3uAZWVIuBu6dDmGa3m8a6zo2VQQpu8ambq9H22UyUpn7590joA==",
       "dependencies": {
-        "@date-io/core": "^2.13.2"
+        "@date-io/core": "^2.16.0"
       },
       "peerDependencies": {
         "date-fns": "^2.0.0"
@@ -552,11 +555,11 @@
       }
     },
     "node_modules/@date-io/dayjs": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/@date-io/dayjs/-/dayjs-2.13.2.tgz",
-      "integrity": "sha512-uP/Bvr+QfzpLN3JGX/x3uJtGnnSWckn7e500Wn+pVNVvIleaXSJxDbE5IAz1P7WwQrnSuxuBI1e6Sl8J/njzKQ==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@date-io/dayjs/-/dayjs-2.16.0.tgz",
+      "integrity": "sha512-y5qKyX2j/HG3zMvIxTobYZRGnd1FUW2olZLS0vTj7bEkBQkjd2RO7/FEwDY03Z1geVGlXKnzIATEVBVaGzV4Iw==",
       "dependencies": {
-        "@date-io/core": "^2.13.2"
+        "@date-io/core": "^2.16.0"
       },
       "peerDependencies": {
         "dayjs": "^1.8.17"
@@ -568,14 +571,14 @@
       }
     },
     "node_modules/@date-io/luxon": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/@date-io/luxon/-/luxon-2.13.2.tgz",
-      "integrity": "sha512-/LeUXsBeM9DITZliaAzKYBu6GtaD3AT5nQR5u7AasjUz1JlYPCTjV5z8b+wnY/jm4bFz5AhgK+TMHGaZoMJW+w==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@date-io/luxon/-/luxon-2.16.1.tgz",
+      "integrity": "sha512-aeYp5K9PSHV28946pC+9UKUi/xMMYoaGelrpDibZSgHu2VWHXrr7zWLEr+pMPThSs5vt8Ei365PO+84pCm37WQ==",
       "dependencies": {
-        "@date-io/core": "^2.13.2"
+        "@date-io/core": "^2.16.0"
       },
       "peerDependencies": {
-        "luxon": "^1.21.3 || ^2.x"
+        "luxon": "^1.21.3 || ^2.x || ^3.x"
       },
       "peerDependenciesMeta": {
         "luxon": {
@@ -584,11 +587,11 @@
       }
     },
     "node_modules/@date-io/moment": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/@date-io/moment/-/moment-2.13.2.tgz",
-      "integrity": "sha512-6uWeCS44srr86MaeUS0mS10T1g7WKfqZ47r1rEc+8xcS3640TIPNf/pg30kwprZKAM7gtbZu6vW6pe1MEPbcKA==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@date-io/moment/-/moment-2.16.1.tgz",
+      "integrity": "sha512-JkxldQxUqZBfZtsaCcCMkm/dmytdyq5pS1RxshCQ4fHhsvP5A7gSqPD22QbVXMcJydi3d3v1Y8BQdUKEuGACZQ==",
       "dependencies": {
-        "@date-io/core": "^2.13.2"
+        "@date-io/core": "^2.16.0"
       },
       "peerDependencies": {
         "moment": "^2.24.0"
@@ -1705,6 +1708,52 @@
         }
       }
     },
+    "node_modules/@mui/lab/node_modules/@mui/x-date-pickers": {
+      "version": "5.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-5.0.0-alpha.0.tgz",
+      "integrity": "sha512-JTzTaNSWbxNi8KDUJjHCH6im0YlIEv88gPoKhGm7s6xCGT1q6FtMp/oQ40nhfwrJ73nkM5G1JXRIzI/yfsHXQQ==",
+      "dependencies": {
+        "@date-io/date-fns": "^2.11.0",
+        "@date-io/dayjs": "^2.11.0",
+        "@date-io/luxon": "^2.11.1",
+        "@date-io/moment": "^2.11.0",
+        "@mui/utils": "^5.2.3",
+        "clsx": "^1.1.1",
+        "prop-types": "^15.7.2",
+        "react-transition-group": "^4.4.2",
+        "rifm": "^0.12.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.2.3",
+        "@mui/system": "^5.2.3",
+        "date-fns": "^2.25.0",
+        "dayjs": "^1.10.7",
+        "luxon": "^1.28.0 || ^2.0.0",
+        "moment": "^2.29.1",
+        "react": "^17.0.2"
+      },
+      "peerDependenciesMeta": {
+        "date-fns": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@mui/material": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.7.0.tgz",
@@ -1871,15 +1920,15 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.7.0.tgz",
-      "integrity": "sha512-uWpDIEXl7bWYkJwKQQ4Rdhc2dcotVETRYuLy29V6qLYZyAbs7AMKwDDz0XKy3RMNmU7S2R/jEeSb9xjXscQUHQ==",
+      "version": "5.10.9",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.10.9.tgz",
+      "integrity": "sha512-2tdHWrq3+WCy+G6TIIaFx3cg7PorXZ71P375ExuX61od1NOAJP1mK90VxQ8N4aqnj2vmO3AQDkV4oV2Ktvt4bA==",
       "dependencies": {
-        "@babel/runtime": "^7.17.2",
+        "@babel/runtime": "^7.19.0",
         "@types/prop-types": "^15.7.5",
         "@types/react-is": "^16.7.1 || ^17.0.0",
         "prop-types": "^15.8.1",
-        "react-is": "^17.0.2"
+        "react-is": "^18.2.0"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1892,19 +1941,27 @@
         "react": "^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@mui/utils/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
     "node_modules/@mui/x-date-pickers": {
-      "version": "5.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-5.0.0-alpha.0.tgz",
-      "integrity": "sha512-JTzTaNSWbxNi8KDUJjHCH6im0YlIEv88gPoKhGm7s6xCGT1q6FtMp/oQ40nhfwrJ73nkM5G1JXRIzI/yfsHXQQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-5.0.7.tgz",
+      "integrity": "sha512-NhxG4tGj+NabxTCQxw4d5RVYl8yzBycHw3YbfawaPVRAsBk/1p3ktSdTbiEi/j+8IUrT8C7Kh/XMNNnOwub/3Q==",
       "dependencies": {
-        "@date-io/date-fns": "^2.11.0",
-        "@date-io/dayjs": "^2.11.0",
-        "@date-io/luxon": "^2.11.1",
-        "@date-io/moment": "^2.11.0",
-        "@mui/utils": "^5.2.3",
-        "clsx": "^1.1.1",
+        "@babel/runtime": "^7.18.9",
+        "@date-io/core": "^2.15.0",
+        "@date-io/date-fns": "^2.15.0",
+        "@date-io/dayjs": "^2.15.0",
+        "@date-io/luxon": "^2.15.0",
+        "@date-io/moment": "^2.15.0",
+        "@mui/utils": "^5.10.3",
+        "@types/react-transition-group": "^4.4.5",
+        "clsx": "^1.2.1",
         "prop-types": "^15.7.2",
-        "react-transition-group": "^4.4.2",
+        "react-transition-group": "^4.4.5",
         "rifm": "^0.12.1"
       },
       "engines": {
@@ -1915,15 +1972,24 @@
         "url": "https://opencollective.com/mui"
       },
       "peerDependencies": {
-        "@mui/material": "^5.2.3",
-        "@mui/system": "^5.2.3",
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.4.1",
+        "@mui/system": "^5.4.1",
         "date-fns": "^2.25.0",
         "dayjs": "^1.10.7",
-        "luxon": "^1.28.0 || ^2.0.0",
+        "luxon": "^1.28.0 || ^2.0.0 || ^3.0.0",
         "moment": "^2.29.1",
-        "react": "^17.0.2"
+        "react": "^17.0.2 || ^18.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0"
       },
       "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
         "date-fns": {
           "optional": true
         },
@@ -2611,9 +2677,9 @@
       }
     },
     "node_modules/@types/react-transition-group": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.4.tgz",
-      "integrity": "sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -3465,9 +3531,9 @@
       }
     },
     "node_modules/clsx": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
-      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
       "engines": {
         "node": ">=6"
       }
@@ -3675,6 +3741,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
+      "integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -8634,9 +8705,9 @@
       }
     },
     "node_modules/react-transition-group": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
-      "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -8662,9 +8733,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.10",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
+      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
@@ -10092,11 +10163,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
-      "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
+      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.10"
       }
     },
     "@babel/runtime-corejs3": {
@@ -10152,40 +10223,40 @@
       "dev": true
     },
     "@date-io/core": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/@date-io/core/-/core-2.13.2.tgz",
-      "integrity": "sha512-lAUDhC5kpzlxa00BxfqENBgerbGI5ojuKQpXLGZCTrqT1rQR+vrp2rwf0I+H2KlM2z3N1ldyQuANmzZ+ehomog=="
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@date-io/core/-/core-2.16.0.tgz",
+      "integrity": "sha512-DYmSzkr+jToahwWrsiRA2/pzMEtz9Bq1euJwoOuYwuwIYXnZFtHajY2E6a1VNVDc9jP8YUXK1BvnZH9mmT19Zg=="
     },
     "@date-io/date-fns": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-2.13.2.tgz",
-      "integrity": "sha512-Pq0xBH6cvEg5IsOs7Olkk1PHFFJFTM34OT5mk/9ND1ied4RGhLNeLYRwbyCThZ29jolqPsV2HBs9wo2QTiNIkg==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-2.16.0.tgz",
+      "integrity": "sha512-bfm5FJjucqlrnQcXDVU5RD+nlGmL3iWgkHTq3uAZWVIuBu6dDmGa3m8a6zo2VQQpu8ambq9H22UyUpn7590joA==",
       "requires": {
-        "@date-io/core": "^2.13.2"
+        "@date-io/core": "^2.16.0"
       }
     },
     "@date-io/dayjs": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/@date-io/dayjs/-/dayjs-2.13.2.tgz",
-      "integrity": "sha512-uP/Bvr+QfzpLN3JGX/x3uJtGnnSWckn7e500Wn+pVNVvIleaXSJxDbE5IAz1P7WwQrnSuxuBI1e6Sl8J/njzKQ==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@date-io/dayjs/-/dayjs-2.16.0.tgz",
+      "integrity": "sha512-y5qKyX2j/HG3zMvIxTobYZRGnd1FUW2olZLS0vTj7bEkBQkjd2RO7/FEwDY03Z1geVGlXKnzIATEVBVaGzV4Iw==",
       "requires": {
-        "@date-io/core": "^2.13.2"
+        "@date-io/core": "^2.16.0"
       }
     },
     "@date-io/luxon": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/@date-io/luxon/-/luxon-2.13.2.tgz",
-      "integrity": "sha512-/LeUXsBeM9DITZliaAzKYBu6GtaD3AT5nQR5u7AasjUz1JlYPCTjV5z8b+wnY/jm4bFz5AhgK+TMHGaZoMJW+w==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@date-io/luxon/-/luxon-2.16.1.tgz",
+      "integrity": "sha512-aeYp5K9PSHV28946pC+9UKUi/xMMYoaGelrpDibZSgHu2VWHXrr7zWLEr+pMPThSs5vt8Ei365PO+84pCm37WQ==",
       "requires": {
-        "@date-io/core": "^2.13.2"
+        "@date-io/core": "^2.16.0"
       }
     },
     "@date-io/moment": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/@date-io/moment/-/moment-2.13.2.tgz",
-      "integrity": "sha512-6uWeCS44srr86MaeUS0mS10T1g7WKfqZ47r1rEc+8xcS3640TIPNf/pg30kwprZKAM7gtbZu6vW6pe1MEPbcKA==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@date-io/moment/-/moment-2.16.1.tgz",
+      "integrity": "sha512-JkxldQxUqZBfZtsaCcCMkm/dmytdyq5pS1RxshCQ4fHhsvP5A7gSqPD22QbVXMcJydi3d3v1Y8BQdUKEuGACZQ==",
       "requires": {
-        "@date-io/core": "^2.13.2"
+        "@date-io/core": "^2.16.0"
       }
     },
     "@emotion/babel-plugin": {
@@ -10985,6 +11056,24 @@
         "react-is": "^17.0.2",
         "react-transition-group": "^4.4.2",
         "rifm": "^0.12.1"
+      },
+      "dependencies": {
+        "@mui/x-date-pickers": {
+          "version": "5.0.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-5.0.0-alpha.0.tgz",
+          "integrity": "sha512-JTzTaNSWbxNi8KDUJjHCH6im0YlIEv88gPoKhGm7s6xCGT1q6FtMp/oQ40nhfwrJ73nkM5G1JXRIzI/yfsHXQQ==",
+          "requires": {
+            "@date-io/date-fns": "^2.11.0",
+            "@date-io/dayjs": "^2.11.0",
+            "@date-io/luxon": "^2.11.1",
+            "@date-io/moment": "^2.11.0",
+            "@mui/utils": "^5.2.3",
+            "clsx": "^1.1.1",
+            "prop-types": "^15.7.2",
+            "react-transition-group": "^4.4.2",
+            "rifm": "^0.12.1"
+          }
+        }
       }
     },
     "@mui/material": {
@@ -11054,30 +11143,40 @@
       "requires": {}
     },
     "@mui/utils": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.7.0.tgz",
-      "integrity": "sha512-uWpDIEXl7bWYkJwKQQ4Rdhc2dcotVETRYuLy29V6qLYZyAbs7AMKwDDz0XKy3RMNmU7S2R/jEeSb9xjXscQUHQ==",
+      "version": "5.10.9",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.10.9.tgz",
+      "integrity": "sha512-2tdHWrq3+WCy+G6TIIaFx3cg7PorXZ71P375ExuX61od1NOAJP1mK90VxQ8N4aqnj2vmO3AQDkV4oV2Ktvt4bA==",
       "requires": {
-        "@babel/runtime": "^7.17.2",
+        "@babel/runtime": "^7.19.0",
         "@types/prop-types": "^15.7.5",
         "@types/react-is": "^16.7.1 || ^17.0.0",
         "prop-types": "^15.8.1",
-        "react-is": "^17.0.2"
+        "react-is": "^18.2.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        }
       }
     },
     "@mui/x-date-pickers": {
-      "version": "5.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-5.0.0-alpha.0.tgz",
-      "integrity": "sha512-JTzTaNSWbxNi8KDUJjHCH6im0YlIEv88gPoKhGm7s6xCGT1q6FtMp/oQ40nhfwrJ73nkM5G1JXRIzI/yfsHXQQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-5.0.7.tgz",
+      "integrity": "sha512-NhxG4tGj+NabxTCQxw4d5RVYl8yzBycHw3YbfawaPVRAsBk/1p3ktSdTbiEi/j+8IUrT8C7Kh/XMNNnOwub/3Q==",
       "requires": {
-        "@date-io/date-fns": "^2.11.0",
-        "@date-io/dayjs": "^2.11.0",
-        "@date-io/luxon": "^2.11.1",
-        "@date-io/moment": "^2.11.0",
-        "@mui/utils": "^5.2.3",
-        "clsx": "^1.1.1",
+        "@babel/runtime": "^7.18.9",
+        "@date-io/core": "^2.15.0",
+        "@date-io/date-fns": "^2.15.0",
+        "@date-io/dayjs": "^2.15.0",
+        "@date-io/luxon": "^2.15.0",
+        "@date-io/moment": "^2.15.0",
+        "@mui/utils": "^5.10.3",
+        "@types/react-transition-group": "^4.4.5",
+        "clsx": "^1.2.1",
         "prop-types": "^15.7.2",
-        "react-transition-group": "^4.4.2",
+        "react-transition-group": "^4.4.5",
         "rifm": "^0.12.1"
       }
     },
@@ -11560,9 +11659,9 @@
       }
     },
     "@types/react-transition-group": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.4.tgz",
-      "integrity": "sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==",
       "requires": {
         "@types/react": "*"
       }
@@ -12184,9 +12283,9 @@
       }
     },
     "clsx": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
-      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
     },
     "co": {
       "version": "4.6.0",
@@ -12359,6 +12458,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "dayjs": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
+      "integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ=="
     },
     "debug": {
       "version": "4.3.4",
@@ -16038,9 +16142,9 @@
       }
     },
     "react-transition-group": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
-      "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -16059,9 +16163,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.10",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
+      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",

--- a/client/package.json
+++ b/client/package.json
@@ -10,8 +10,8 @@
     "prod": "next start",
     "snapshots": "jest --updateSnapshot",
     "start": "next dev",
-    "test": "jest --coverage",
-    "testWatch": "jest --watch --coverage"
+    "test": "TZ='America/New_York' jest --coverage",
+    "testWatch": "TZ='America/New_York' jest --watch --coverage"
   },
   "dependencies": {
     "@date-io/dayjs": "^2.16.0",

--- a/client/package.json
+++ b/client/package.json
@@ -10,8 +10,8 @@
     "prod": "next start",
     "snapshots": "jest --updateSnapshot",
     "start": "next dev",
-    "test": "TZ='America/New_York' jest --coverage",
-    "testWatch": "TZ='America/New_York' jest --watch --coverage"
+    "test": "jest --coverage",
+    "testWatch": "jest --watch --coverage"
   },
   "dependencies": {
     "@date-io/dayjs": "^2.16.0",

--- a/client/package.json
+++ b/client/package.json
@@ -14,12 +14,15 @@
     "testWatch": "jest --watch --coverage"
   },
   "dependencies": {
+    "@date-io/dayjs": "^2.16.0",
     "@emotion/styled": "^11.8.1",
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@mui/icons-material": "^5.4.1",
     "@mui/lab": "^5.0.0-alpha.73",
     "@mui/material": "^5.3.0",
+    "@mui/x-date-pickers": "^5.0.7",
     "@tinymce/tinymce-react": "^4.2.0",
+    "dayjs": "^1.11.6",
     "html-react-parser": "^1.4.6",
     "identity-obj-proxy": "^3.0.0",
     "next": "12.1.5",

--- a/client/util/routes.ts
+++ b/client/util/routes.ts
@@ -108,7 +108,7 @@ const objectDatastreamDublinCoreUrl = (pid: string, datastream: string) => {
     return getDatastreamActionUrl(pid, datastream, "dublinCore")
 };
 
-const objectDatastreamProcessMetadataUrl = (pid: string, datastream: string) => {
+const objectDatastreamProcessMetadataUrl = (pid: string, datastream: string): string => {
     return getDatastreamActionUrl(pid, datastream, "processMetadata")
 };
 

--- a/client/util/routes.ts
+++ b/client/util/routes.ts
@@ -108,6 +108,10 @@ const objectDatastreamDublinCoreUrl = (pid: string, datastream: string) => {
     return getDatastreamActionUrl(pid, datastream, "dublinCore")
 };
 
+const objectDatastreamProcessMetadataUrl = (pid: string, datastream: string) => {
+    return getDatastreamActionUrl(pid, datastream, "processMetadata")
+};
+
 export {
     baseUrl,
     apiUrl,
@@ -140,4 +144,5 @@ export {
     objectDatastreamLicenseUrl,
     objectDatastreamAgentsUrl,
     objectDatastreamDublinCoreUrl,
+    objectDatastreamProcessMetadataUrl,
 };


### PR DESCRIPTION
This PR adds the PROCESS-MD datastream editor

TODO
- [x] Read existing data from Fedora
- [x] Display editor form
  - [x] Basic top-level text fields
  - [x] Date control
  - [x] Multiple tasks
- [x] Save modified data to Fedora
- [x] Configurable catalog of task tools
- [x] Test everything
  - [x] Unit tests for back end code
  - [x] Unit tests for front end code
  - [x] Investigate whether tests can be improved by mocking `date.prototype.getTimezoneOffset` instead of setting time zone on the command line in package.json.