### PR TITLE
Update GitHub actions versions.

### DIFF
--- a/.github/workflows/lint-prs.yml
+++ b/.github/workflows/lint-prs.yml
@@ -9,12 +9,12 @@ jobs:
 
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '15'
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install npm dependencies
         run: |
@@ -25,7 +25,7 @@ jobs:
         run: npm run format
 
       - name: Auto-commit fixes
-        uses: EndBug/add-and-commit@v7
+        uses: EndBug/add-and-commit@v9
         with:
           default_author: github_actions
           add: "['api/*.js', 'api/src/', 'client/src/']"


### PR DESCRIPTION
This PR brings some of the GitHub actions steps we're using more up to date, in an effort to reduce warning messages. Thanks to @diboy2 for researching the details.

TODO
- [x] Make sure the build passes before merging.