### PR TITLE
Make BlurSavingTextField more efficient.

### DIFF
--- a/client/components/shared/BlurSavingTextField.test.tsx
+++ b/client/components/shared/BlurSavingTextField.test.tsx
@@ -12,11 +12,14 @@ jest.mock("@mui/material/TextField", function () {
 describe("BlurSavingTextField", () => {
     let props: BlurSavingTextFieldProps;
     let value: string;
+    let setterWasCalled: boolean;
     beforeEach(() => {
         value = "foo";
+        setterWasCalled = false;
         props = {
             value,
             setValue: (x: string) => {
+                setterWasCalled = true;
                 value = x;
             },
         };
@@ -52,6 +55,20 @@ describe("BlurSavingTextField", () => {
                 .props()
                 .onBlur({ target: { value: "bar" } });
         });
+        expect(setterWasCalled).toEqual(true);
         expect(value).toEqual("bar");
+    });
+
+    it("doesn't call the save callback if nothing has changed", () => {
+        const wrapper = mount(<BlurSavingTextField {...props} />);
+        act(() => {
+            wrapper
+                .children()
+                .at(0)
+                .props()
+                .onBlur({ target: { value: "foo" } });
+        });
+        expect(setterWasCalled).toEqual(false);
+        expect(value).toEqual("foo");
     });
 });

--- a/client/components/shared/BlurSavingTextField.tsx
+++ b/client/components/shared/BlurSavingTextField.tsx
@@ -10,7 +10,9 @@ export interface BlurSavingTextFieldProps {
 const BlurSavingTextField = ({ value, setValue, options = {} }: BlurSavingTextFieldProps): React.ReactElement => {
     const [temporaryValue, setTemporaryValue] = useState(value);
     const handleBlurEvent = (event: React.ChangeEvent) => {
-        setValue(event.target.value);
+        if (event.target.value !== value) {
+            setValue(event.target.value);
+        }
     };
     const handleChangeEvent = (event: React.ChangeEvent) => {
         setTemporaryValue(event.target.value);


### PR DESCRIPTION
We don't need to save changes on blur if nothing actually changed. This improves performance significantly when navigating through forms.