### PR TITLE
Relocate show/hide thumbnails control.

### DIFF
--- a/client/components/edit/children/ChildList.tsx
+++ b/client/components/edit/children/ChildList.tsx
@@ -44,6 +44,7 @@ export const ChildList = ({
     const thumbsButton =
         forceThumbs === null ? (
             <button
+                style={{ float: "right", marginTop: "-2em" }}
                 onClick={() => {
                     setShowThumbs(!showThumbs);
                 }}

--- a/client/components/edit/children/__snapshots__/ChildList.test.tsx.snap
+++ b/client/components/edit/children/__snapshots__/ChildList.test.tsx.snap
@@ -9,6 +9,12 @@ exports[`ChildList allows thumbnails to be toggled on 1`] = `
     >
       <button
         onClick={[Function]}
+        style={
+          Object {
+            "float": "right",
+            "marginTop": "-2em",
+          }
+        }
       >
         Hide Thumbnails
       </button>
@@ -42,6 +48,12 @@ exports[`ChildList displays a paginator when appropriate 1`] = `
     >
       <button
         onClick={[Function]}
+        style={
+          Object {
+            "float": "right",
+            "marginTop": "-2em",
+          }
+        }
       >
         Show Thumbnails
       </button>
@@ -191,6 +203,12 @@ exports[`ChildList renders using SelectableChild when a callback is provided 1`]
     >
       <button
         onClick={[Function]}
+        style={
+          Object {
+            "float": "right",
+            "marginTop": "-2em",
+          }
+        }
       >
         Show Thumbnails
       </button>
@@ -224,6 +242,12 @@ exports[`ChildList renders using ajax-loaded object data 1`] = `
     >
       <button
         onClick={[Function]}
+        style={
+          Object {
+            "float": "right",
+            "marginTop": "-2em",
+          }
+        }
       >
         Show Thumbnails
       </button>
@@ -257,6 +281,12 @@ exports[`ChildList renders using ajax-loaded root data 1`] = `
     >
       <button
         onClick={[Function]}
+        style={
+          Object {
+            "float": "right",
+            "marginTop": "-2em",
+          }
+        }
       >
         Show Thumbnails
       </button>


### PR DESCRIPTION
This moves the show/hide thumbnails button to a better location. It's done in a pretty hacky way, and I hope that @crhallberg can improve upon it at some point when he takes a look at styles throughout the project... but it works for day one!