### PR TITLE
Adjust package names; remove version attributes.

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "vudlprepjsapi",
-  "version": "0.0.0",
+  "name": "vudl-api",
   "private": true,
   "scripts": {
     "format": "prettier --check --write *.js src/**",

--- a/client/package.json
+++ b/client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "client",
+  "name": "vudl-client",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "vudlprepjs",
-  "version": "0.0.0",
+  "name": "vudl",
   "private": true,
   "comments": {
     "dev": "tsc can't be bundled into concurrently because it suppresses the logs of other processes. Still needs to be run separately."


### PR DESCRIPTION
This PR adjusts package names to get rid of the old vudlprepjs name and removes version numbers so we don't have to worry about them getting out of sync with reality (since we will not be publishing this package for installation via package managers).