### PR TITLE
Use Solr cache to reduce Fedora and Redis load.

### DIFF
--- a/api/src/jobs/Index.test.ts
+++ b/api/src/jobs/Index.test.ts
@@ -1,6 +1,7 @@
 import Index from "./Index";
 import { Job } from "bullmq";
 import { NeedleResponse } from "../services/interfaces";
+import SolrCache from "../services/SolrCache";
 import SolrIndexer from "../services/SolrIndexer";
 
 jest.mock("../services/SolrIndexer");
@@ -17,6 +18,7 @@ describe("Index", () => {
         let needleResponse: NeedleResponse;
         let consoleErrorSpy;
         let consoleLogSpy;
+        let unlockPidSpy;
         beforeEach(() => {
             needleResponse = {
                 statusCode: 200,
@@ -34,6 +36,7 @@ describe("Index", () => {
             jest.spyOn(SolrIndexer, "getInstance").mockReturnValue(indexer);
             consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(jest.fn());
             consoleLogSpy = jest.spyOn(console, "log").mockImplementation(jest.fn());
+            unlockPidSpy = jest.spyOn(SolrCache.getInstance(), "unlockPidIfEnabled").mockImplementation(jest.fn());
         });
 
         afterEach(() => {
@@ -49,12 +52,14 @@ describe("Index", () => {
             expect(consoleLogSpy).toHaveBeenCalledTimes(1);
             expect(consoleLogSpy).toHaveBeenCalledWith("Indexing...", { action: "delete", pid: "vudl:123" });
             expect(indexer.deletePid).toHaveBeenCalledWith(job.data.pid);
+            expect(unlockPidSpy).toHaveBeenCalledWith("vudl:123", "delete");
         });
 
         it("handles empty job gracefully", async () => {
             jest.spyOn(indexer, "indexPid").mockResolvedValue(needleResponse);
 
             await expect(index.run(null)).rejects.toThrow(/No pid provided/);
+            expect(unlockPidSpy).not.toHaveBeenCalled();
         });
 
         it("handles empty data gracefully", async () => {
@@ -62,6 +67,7 @@ describe("Index", () => {
             jest.spyOn(indexer, "indexPid").mockResolvedValue(needleResponse);
 
             await expect(index.run(job)).rejects.toThrow(/No pid provided/);
+            expect(unlockPidSpy).not.toHaveBeenCalled();
         });
 
         it("handles missing pid gracefully", async () => {
@@ -69,6 +75,7 @@ describe("Index", () => {
             jest.spyOn(indexer, "indexPid").mockResolvedValue(needleResponse);
 
             await expect(index.run(job)).rejects.toThrow(/No pid provided/);
+            expect(unlockPidSpy).not.toHaveBeenCalled();
         });
 
         it("handles missing action gracefully", async () => {
@@ -76,6 +83,7 @@ describe("Index", () => {
             jest.spyOn(indexer, "indexPid").mockResolvedValue(needleResponse);
 
             await expect(index.run(job)).rejects.toThrow(/Unexpected index action: undefined/);
+            expect(unlockPidSpy).not.toHaveBeenCalled();
         });
 
         it("indexes the pid", async () => {
@@ -88,12 +96,14 @@ describe("Index", () => {
             expect(consoleLogSpy).toHaveBeenCalledTimes(1);
             expect(consoleLogSpy).toHaveBeenCalledWith("Indexing...", { action: "index", pid: "vudl:123" });
             expect(indexer.indexPid).toHaveBeenCalledWith(job.data.pid);
+            expect(unlockPidSpy).toHaveBeenCalledWith("vudl:123", "index");
         });
 
         it("throws an error when action does not exist", async () => {
             job.data.action = "fake action";
 
             await expect(index.run(job)).rejects.toThrow(/Unexpected index/);
+            expect(unlockPidSpy).not.toHaveBeenCalled();
         });
 
         it("throws an error for statusCode not 200", async () => {
@@ -103,6 +113,7 @@ describe("Index", () => {
 
             expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
             expect(consoleErrorSpy).toHaveBeenCalledWith("Problem performing delete on vudl:123: unspecified error");
+            expect(unlockPidSpy).toHaveBeenCalledWith("vudl:123", "delete");
         });
     });
 });

--- a/api/src/jobs/Index.test.ts
+++ b/api/src/jobs/Index.test.ts
@@ -28,7 +28,7 @@ describe("Index", () => {
             job = {
                 data: {
                     action: "delete",
-                    pid: 123,
+                    pid: "vudl:123",
                 },
             } as Job;
             jest.spyOn(SolrIndexer, "getInstance").mockReturnValue(indexer);
@@ -47,7 +47,7 @@ describe("Index", () => {
 
             expect(consoleErrorSpy).toHaveBeenCalledTimes(0);
             expect(consoleLogSpy).toHaveBeenCalledTimes(1);
-            expect(consoleLogSpy).toHaveBeenCalledWith("Indexing...", { action: "delete", pid: 123 });
+            expect(consoleLogSpy).toHaveBeenCalledWith("Indexing...", { action: "delete", pid: "vudl:123" });
             expect(indexer.deletePid).toHaveBeenCalledWith(job.data.pid);
         });
 
@@ -86,7 +86,7 @@ describe("Index", () => {
 
             expect(consoleErrorSpy).toHaveBeenCalledTimes(0);
             expect(consoleLogSpy).toHaveBeenCalledTimes(1);
-            expect(consoleLogSpy).toHaveBeenCalledWith("Indexing...", { action: "index", pid: 123 });
+            expect(consoleLogSpy).toHaveBeenCalledWith("Indexing...", { action: "index", pid: "vudl:123" });
             expect(indexer.indexPid).toHaveBeenCalledWith(job.data.pid);
         });
 
@@ -102,7 +102,7 @@ describe("Index", () => {
             await expect(index.run(job)).rejects.toThrow(/Problem performing/);
 
             expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-            expect(consoleErrorSpy).toHaveBeenCalledWith("Problem performing delete on 123: unspecified error");
+            expect(consoleErrorSpy).toHaveBeenCalledWith("Problem performing delete on vudl:123: unspecified error");
         });
     });
 });

--- a/api/src/jobs/Index.ts
+++ b/api/src/jobs/Index.ts
@@ -1,6 +1,7 @@
 import { Job } from "bullmq";
 import QueueJob from "./QueueJobInterface";
 import SolrIndexer from "../services/SolrIndexer";
+import SolrCache from "../services/SolrCache";
 
 class Index implements QueueJob {
     async run(job: Job): Promise<void> {
@@ -9,6 +10,11 @@ class Index implements QueueJob {
             throw new Error("No pid provided!");
         }
         const indexer = SolrIndexer.getInstance();
+
+        // Unlock the PID if it is locked so subsequent jobs can be queued:
+        const cache = SolrCache.getInstance();
+        cache.unlockPidIfEnabled(job.data.pid, job.data.action);
+
         let result = null;
         switch (job.data.action) {
             case "delete":

--- a/api/src/jobs/Index.ts
+++ b/api/src/jobs/Index.ts
@@ -13,14 +13,15 @@ class Index implements QueueJob {
 
         // Unlock the PID if it is locked so subsequent jobs can be queued:
         const cache = SolrCache.getInstance();
-        cache.unlockPidIfEnabled(job.data.pid, job.data.action);
 
         let result = null;
         switch (job.data.action) {
             case "delete":
+                cache.unlockPidIfEnabled(job.data.pid, job.data.action);
                 result = await indexer.deletePid(job.data.pid);
                 break;
             case "index":
+                cache.unlockPidIfEnabled(job.data.pid, job.data.action);
                 result = await indexer.indexPid(job.data.pid);
                 break;
             default:

--- a/api/src/jobs/Ingest.test.ts
+++ b/api/src/jobs/Ingest.test.ts
@@ -5,6 +5,7 @@ import FedoraObjectFactory from "../services/FedoraObjectFactory";
 import { IngestProcessor } from "./Ingest";
 import Database from "../services/Database";
 import QueueManager from "../services/QueueManager";
+import SolrCache from "../services/SolrCache";
 import fs = require("fs");
 import winston = require("winston");
 
@@ -30,7 +31,7 @@ describe("IngestProcessor", () => {
             level: "error", // we don't want to see info messages while testing
             transports: [new winston.transports.Console()],
         });
-        job = new Job(dir + "/" + jobName, config, new QueueManager(config));
+        job = new Job(dir + "/" + jobName, config, new QueueManager(config, new SolrCache(false)));
         jest.spyOn(Job, "build").mockReturnValue(job);
         ingest = new IngestProcessor(dir, config, new FedoraObjectFactory(config, {} as Database), logger);
     });

--- a/api/src/models/FedoraObject.test.ts
+++ b/api/src/models/FedoraObject.test.ts
@@ -4,6 +4,7 @@ import FedoraDataCollector from "../services/FedoraDataCollector";
 import FedoraDataCollection from "./FedoraDataCollection";
 import * as fs from "fs";
 import Config from "../models/Config";
+import SolrCache from "../services/SolrCache";
 
 jest.mock("fs");
 
@@ -54,7 +55,7 @@ describe("FedoraObject", () => {
                     },
                 },
             });
-            const fedora = new Fedora(config);
+            const fedora = new Fedora(config, new SolrCache(false));
             fedoraObject = new FedoraObject(pid, config, fedora, FedoraDataCollector.getInstance());
             const spy = jest.spyOn(fedoraObject, "addDatastreamFromStringOrBuffer").mockImplementation(jest.fn());
 
@@ -92,7 +93,7 @@ describe("FedoraObject", () => {
             ["doubleQuotes", [`""`], "<METS:note>&quot;&quot;</METS:note>"],
         ])("adds a datastream for an agent with %s notes", async (numString, testInput, notesXml) => {
             const config = new Config({});
-            const fedora = new Fedora(config);
+            const fedora = new Fedora(config, new SolrCache(false));
             fedoraObject = new FedoraObject(pid, config, fedora, FedoraDataCollector.getInstance());
             const spy = jest.spyOn(fedoraObject, "addDatastreamFromStringOrBuffer").mockImplementation(jest.fn());
             agents[0].notes = testInput;

--- a/api/src/models/Job.test.ts
+++ b/api/src/models/Job.test.ts
@@ -1,6 +1,7 @@
 import Config from "./Config";
 import Job from "./Job";
 import QueueManager from "../services/QueueManager";
+import SolrCache from "../services/SolrCache";
 
 jest.mock("./Config");
 jest.mock("../services/QueueManager");
@@ -16,7 +17,7 @@ describe("Job", () => {
 
     beforeEach(() => {
         const config = new Config({});
-        job = new Job("test1", config, new QueueManager(config));
+        job = new Job("test1", config, new QueueManager(config, new SolrCache(false)));
     });
 
     it("should return the name", () => {

--- a/api/src/models/JobMetadata.test.ts
+++ b/api/src/models/JobMetadata.test.ts
@@ -4,6 +4,7 @@ import Job from "./Job";
 import JobMetadata from "./JobMetadata";
 import PageOrder from "./PageOrder";
 import QueueManager from "../services/QueueManager";
+import SolrCache from "../services/SolrCache";
 import VideoOrder from "./VideoOrder";
 
 jest.mock("./Config");
@@ -22,7 +23,7 @@ describe("JobMetadata", () => {
 
     beforeEach(() => {
         config = new Config({});
-        job = new Job("test1", config, new QueueManager(config));
+        job = new Job("test1", config, new QueueManager(config, new SolrCache(false)));
         jobMetadata = new JobMetadata(job);
     });
 

--- a/api/src/services/FedoraDataCollector.ts
+++ b/api/src/services/FedoraDataCollector.ts
@@ -49,6 +49,7 @@ class FedoraDataCollector {
             fedoraDetails = this.extractor.extractFedoraDetails(RDF);
             fedoraDatastreams = this.extractor.extractFedoraDatastreams(RDF);
         } else {
+            // Parse data out of local cache (reversing work done by Solr indexer)
             metadata = {};
             fedoraDetails = {};
             const keys = Object.keys(cachedRecord);

--- a/api/src/services/QueueManager.test.ts
+++ b/api/src/services/QueueManager.test.ts
@@ -2,6 +2,7 @@ import QueueManager from "./QueueManager";
 import { Queue } from "bullmq";
 import * as BullMQ from "bullmq";
 import Config from "../models/Config";
+import SolrCache from "../services/SolrCache";
 
 let workerArgs;
 function workerConstructor(...args) {
@@ -13,6 +14,7 @@ jest.mock("bullmq", () => {
         Worker: jest.fn().mockImplementation(workerConstructor),
     };
 });
+
 Queue.prototype.add = jest.fn();
 Queue.prototype.close = jest.fn();
 Queue.prototype.getJobs = jest.fn();
@@ -56,6 +58,7 @@ describe("QueueManager", () => {
         it("supports non-default queue/connection configuration", async () => {
             const customQueueManager = new QueueManager(
                 new Config({ queue: { connection: { foo: "bar" }, jobMap: { ingest: "vudl-foo" } } }),
+                new SolrCache(false),
             );
             await customQueueManager.ingestJob("foo");
             expect(addSpy).toHaveBeenCalledWith("ingest", { dir: "foo" });

--- a/api/src/services/QueueManager.test.ts
+++ b/api/src/services/QueueManager.test.ts
@@ -3,6 +3,7 @@ import { Queue } from "bullmq";
 import * as BullMQ from "bullmq";
 import Config from "../models/Config";
 import SolrCache from "../services/SolrCache";
+import Solr from "./Solr";
 
 let workerArgs;
 function workerConstructor(...args) {
@@ -91,48 +92,79 @@ describe("QueueManager", () => {
         });
     });
 
+    describe("hasPendingIndexJob", () => {
+        it("will search the queue for duplicates when cache is disabled", async () => {
+            const job = {
+                name: "index",
+                data: {
+                    pid: "123",
+                    action: "index",
+                },
+            };
+            const jobs = [];
+            jobs.push(job);
+            const queue = new Queue("foo");
+            const getJobsSpy = jest.spyOn(queue, "getJobs").mockResolvedValue(jobs);
+            expect(await queueManager.hasPendingIndexJob(queue, job.data)).toBeTruthy();
+            expect(await queueManager.hasPendingIndexJob(queue, { pid: "nope", action: "maybe" })).toBeFalsy();
+            expect(getJobsSpy).toHaveBeenCalled();
+        });
+
+        it("will use the cache when enabled", async () => {
+            const cache = new SolrCache("/foo");
+            const enabledSpy = jest.spyOn(cache, "isEnabled").mockReturnValue(true);
+            const lockedSpy = jest.spyOn(cache, "isPidLocked").mockReturnValueOnce(true).mockReturnValueOnce(false);
+            const cachedManager = new QueueManager(Config.getInstance(), cache);
+            const queue = new Queue("foo");
+            const getJobsSpy = jest.spyOn(queue, "getJobs").mockImplementation(jest.fn());
+            const jobData = { pid: "foo", action: "bar" };
+            expect(await cachedManager.hasPendingIndexJob(queue, jobData)).toBeTruthy();
+            expect(await cachedManager.hasPendingIndexJob(queue, jobData)).toBeFalsy();
+            expect(getJobsSpy).not.toHaveBeenCalled();
+            expect(enabledSpy).toHaveBeenCalledTimes(2);
+            expect(lockedSpy).toHaveBeenCalledTimes(2);
+            expect(lockedSpy).toHaveBeenCalledWith("foo", "bar");
+        });
+    });
+
     describe("performIndexOperation", () => {
-        let jobs;
-        let getJobsSpy;
         let addSpy;
+        let purgeSpy;
+        let lockSpy;
         beforeEach(() => {
-            jobs = [];
-            getJobsSpy = jest.spyOn(Queue.prototype, "getJobs").mockResolvedValue(jobs);
             addSpy = jest.spyOn(Queue.prototype, "add").mockImplementation(jest.fn());
+            purgeSpy = jest.spyOn(SolrCache.prototype, "purgeFromCacheIfEnabled").mockImplementation(jest.fn());
+            lockSpy = jest.spyOn(SolrCache.prototype, "lockPidIfEnabled").mockImplementation(jest.fn());
         });
 
         it("will not queue an index operation if it already exists (by default)", async () => {
-            jobs.push({
-                name: "index",
-                data: {
-                    pid: "123",
-                    action: "index",
-                },
-            });
             const consoleSpy = jest.spyOn(console, "log").mockImplementation(jest.fn());
+            const pendingSpy = jest.spyOn(queueManager, "hasPendingIndexJob").mockReturnValue(true);
             await queueManager.performIndexOperation("123", "index");
+            expect(pendingSpy).toHaveBeenCalledWith(expect.anything(), { pid: "123", action: "index" });
             expect(addSpy).not.toHaveBeenCalled();
             expect(consoleSpy).toHaveBeenCalledTimes(1);
             expect(consoleSpy).toHaveBeenCalledWith("Skipping queue; 123 is already awaiting index.");
+            expect(purgeSpy).not.toHaveBeenCalled();
+            expect(lockSpy).not.toHaveBeenCalled();
         });
 
         it("will queue an index operation if it already exists if you force it", async () => {
-            jobs.push({
-                name: "index",
-                data: {
-                    pid: "123",
-                    action: "index",
-                },
-            });
+            const pendingSpy = jest.spyOn(queueManager, "hasPendingIndexJob").mockReturnValue(true);
             await queueManager.performIndexOperation("123", "index", true);
+            expect(pendingSpy).not.toHaveBeenCalled();
             expect(addSpy).toHaveBeenCalledWith("index", { pid: "123", action: "index" });
+            expect(purgeSpy).toHaveBeenCalledWith("123");
+            expect(lockSpy).toHaveBeenCalledWith("123", "index");
         });
 
-        it("will queue an index operation", async () => {
+        it("will queue an index operation if it is not a duplicate", async () => {
+            const pendingSpy = jest.spyOn(queueManager, "hasPendingIndexJob").mockReturnValue(false);
             await queueManager.performIndexOperation("123", "index");
-
-            expect(getJobsSpy).toHaveBeenCalledWith("wait");
+            expect(pendingSpy).toHaveBeenCalledWith(expect.anything(), { pid: "123", action: "index" });
             expect(addSpy).toHaveBeenCalledWith("index", { pid: "123", action: "index" });
+            expect(purgeSpy).toHaveBeenCalledWith("123");
+            expect(lockSpy).toHaveBeenCalledWith("123", "index");
         });
     });
 

--- a/api/src/services/QueueManager.test.ts
+++ b/api/src/services/QueueManager.test.ts
@@ -3,7 +3,6 @@ import { Queue } from "bullmq";
 import * as BullMQ from "bullmq";
 import Config from "../models/Config";
 import SolrCache from "../services/SolrCache";
-import Solr from "./Solr";
 
 let workerArgs;
 function workerConstructor(...args) {

--- a/api/src/services/QueueManager.ts
+++ b/api/src/services/QueueManager.ts
@@ -71,7 +71,7 @@ class QueueManager {
 
     protected async hasPendingIndexJob(q, queueJob): Promise<boolean> {
         const jobs = await q.getJobs("wait");
-        return this.isAlreadyAwaitingAction(jobs, "index", queueJob)
+        return this.isAlreadyAwaitingAction(jobs, "index", queueJob);
     }
 
     public async performIndexOperation(pid: string, action: string, force = false): Promise<void> {
@@ -80,7 +80,7 @@ class QueueManager {
         // that is already awaiting indexing.
         const q = this.getQueue(this.getQueueNameForJob("index"));
         const queueJob = { pid, action };
-        if (!force && await this.hasPendingIndexJob(q, queueJob)) {
+        if (!force && (await this.hasPendingIndexJob(q, queueJob))) {
             console.log(`Skipping queue; ${pid} is already awaiting ${action}.`);
         } else {
             // Clear the cache for the pid that needs to be reindexed; we don't want to read an

--- a/api/src/services/QueueManager.ts
+++ b/api/src/services/QueueManager.ts
@@ -83,7 +83,7 @@ class QueueManager {
         // that is already awaiting indexing.
         const q = this.getQueue(this.getQueueNameForJob("index"));
         const queueJob = { pid, action };
-        if (!force && await this.hasPendingIndexJob(q, queueJob)) {
+        if (!force && (await this.hasPendingIndexJob(q, queueJob))) {
             console.log(`Skipping queue; ${pid} is already awaiting ${action}.`);
         } else {
             // Clear the cache for the pid that needs to be reindexed; we don't want to read an

--- a/api/src/services/QueueManager.ts
+++ b/api/src/services/QueueManager.ts
@@ -69,7 +69,7 @@ class QueueManager {
         return await this.addToQueue("reindex", { file });
     }
 
-    protected async hasPendingIndexJob(q, queueJob): Promise<boolean> {
+    public async hasPendingIndexJob(q, queueJob): Promise<boolean> {
         if (this.cache.isEnabled()) {
             return this.cache.isPidLocked(queueJob.pid, queueJob.action);
         }
@@ -95,7 +95,11 @@ class QueueManager {
         q.close();
     }
 
-    isAlreadyAwaitingAction(jobs: Array<Job>, name: string, { pid, action }: { pid: string; action: string }): boolean {
+    protected isAlreadyAwaitingAction(
+        jobs: Array<Job>,
+        name: string,
+        { pid, action }: { pid: string; action: string },
+    ): boolean {
         const matchingJob = jobs.find((job) => {
             return job.name === name && job.data.pid === pid;
         });

--- a/api/src/services/SolrCache.test.ts
+++ b/api/src/services/SolrCache.test.ts
@@ -185,6 +185,7 @@ describe("SolrCache", () => {
         });
         expect(cache.getDocumentFromCache("foo:123")).toEqual({ foo: "bar" });
         expect(existsSpy).toHaveBeenCalledWith("/foo/foo/000/000/123/123.json");
+        expect(readSpy).toHaveBeenCalledTimes(1);
     });
 
     it("disallows lock file generation when disabled", () => {

--- a/api/src/services/SolrCache.test.ts
+++ b/api/src/services/SolrCache.test.ts
@@ -3,6 +3,17 @@ import * as fs from "fs";
 import glob = require("glob");
 
 describe("SolrCache", () => {
+    let existsSpy;
+    let mkdirSpy;
+    let writeFileSpy;
+    let rmSpy;
+    beforeEach(() => {
+        existsSpy = jest.spyOn(fs, "existsSync").mockImplementation(jest.fn());
+        mkdirSpy = jest.spyOn(fs, "mkdirSync").mockImplementation(jest.fn());
+        writeFileSpy = jest.spyOn(fs, "writeFileSync").mockImplementation(jest.fn());
+        rmSpy = jest.spyOn(fs, "rmSync").mockImplementation(jest.fn());
+    });
+
     afterEach(() => {
         jest.restoreAllMocks();
     });
@@ -15,13 +26,11 @@ describe("SolrCache", () => {
         const cache = new SolrCache();
         expect(cache.getDocumentCachePath("vudl:123")).toBeFalsy();
         expect(cache.getDocumentsFromCache()).toBeFalsy();
-        const existsSpy = jest.spyOn(fs, "existsSync").mockImplementation(jest.fn());
-        const mkdirSpy = jest.spyOn(fs, "mkdirSync").mockImplementation(jest.fn());
-        const writeFileSpy = jest.spyOn(fs, "writeFileSync").mockImplementation(jest.fn());
-        const rmSpy = jest.spyOn(fs, "rmSync").mockImplementation(jest.fn());
         cache.purgeFromCacheIfEnabled("vudl:123");
         cache.writeToCacheIfEnabled("vudl:123", "foo");
         cache.exportCombinedFiles("/bar");
+        cache.lockPidIfEnabled("vudl:123", "index");
+        cache.unlockPidIfEnabled("vudl:123", "index");
         expect(existsSpy).not.toHaveBeenCalled();
         expect(mkdirSpy).not.toHaveBeenCalled();
         expect(writeFileSpy).not.toHaveBeenCalled();
@@ -30,8 +39,7 @@ describe("SolrCache", () => {
 
     it("purges files when enabled and they exist", () => {
         const cache = new SolrCache("/foo");
-        const existsSpy = jest.spyOn(fs, "existsSync").mockReturnValue(true);
-        const rmSpy = jest.spyOn(fs, "rmSync").mockImplementation(jest.fn());
+        existsSpy.mockReturnValue(true);
         cache.purgeFromCacheIfEnabled("vudl:123");
         const expectedPath = "/foo/vudl/000/000/123/123.json";
         expect(existsSpy).toHaveBeenCalledWith(expectedPath);
@@ -40,8 +48,7 @@ describe("SolrCache", () => {
 
     it("doesn't purge non-existent files when enabled", () => {
         const cache = new SolrCache("/foo");
-        const existsSpy = jest.spyOn(fs, "existsSync").mockReturnValue(false);
-        const rmSpy = jest.spyOn(fs, "rmSync").mockImplementation(jest.fn());
+        existsSpy.mockReturnValue(false);
         cache.purgeFromCacheIfEnabled("vudl:12345678901");
         const expectedPath = "/foo/vudl/345/678/901/12345678901.json";
         expect(existsSpy).toHaveBeenCalledWith(expectedPath);
@@ -52,9 +59,7 @@ describe("SolrCache", () => {
         const cache = new SolrCache("/foo");
         const expectedDirName = "/foo/vudl/000/000/123";
         const expectedPath = expectedDirName + "/123.json";
-        const existsSpy = jest.spyOn(fs, "existsSync").mockReturnValue(false);
-        const mkdirSpy = jest.spyOn(fs, "mkdirSync").mockImplementation(jest.fn());
-        const writeFileSpy = jest.spyOn(fs, "writeFileSync").mockImplementation(jest.fn());
+        existsSpy.mockReturnValue(false);
         cache.writeToCacheIfEnabled("vudl:123", "foo");
         expect(existsSpy).toHaveBeenCalledWith(expectedDirName);
         expect(mkdirSpy).toHaveBeenCalledWith(expectedDirName, { recursive: true });
@@ -87,16 +92,15 @@ describe("SolrCache", () => {
         const readSpy = jest.spyOn(cache, "readSolrAddDocFromFile").mockImplementation((file: string): SolrAddDoc => {
             return { add: { doc: { file } } };
         });
-        const existsSpy = jest.spyOn(fs, "existsSync").mockReturnValue(true);
-        const writeSpy = jest.spyOn(fs, "writeFileSync").mockImplementation(jest.fn());
+        existsSpy.mockReturnValue(true);
         const logSpy = jest.spyOn(console, "log").mockImplementation(jest.fn());
         cache.exportCombinedFiles("/bar", 2);
         expect(docsSpy).toHaveBeenCalledTimes(1);
         expect(readSpy).toHaveBeenCalledTimes(3);
         expect(existsSpy).toHaveBeenCalled();
-        expect(writeSpy).toHaveBeenCalledTimes(2);
-        expect(writeSpy).toHaveBeenCalledWith("/bar/one", '[{"file":"/foo/one"},{"file":"/foo/two"}]');
-        expect(writeSpy).toHaveBeenCalledWith("/bar/three", '[{"file":"/foo/three"}]');
+        expect(writeFileSpy).toHaveBeenCalledTimes(2);
+        expect(writeFileSpy).toHaveBeenCalledWith("/bar/one", '[{"file":"/foo/one"},{"file":"/foo/two"}]');
+        expect(writeFileSpy).toHaveBeenCalledWith("/bar/three", '[{"file":"/foo/three"}]');
         expect(logSpy).toHaveBeenCalledTimes(2);
         expect(logSpy).toHaveBeenCalledWith("Starting batch /bar/one");
         expect(logSpy).toHaveBeenCalledWith("Starting batch /bar/three");
@@ -108,15 +112,13 @@ describe("SolrCache", () => {
             .spyOn(cache, "getDocumentsFromCache")
             .mockReturnValue(["/foo/one", "/foo/two", "/foo/three"]);
         const readSpy = jest.spyOn(cache, "readSolrAddDocFromFile").mockImplementation(jest.fn());
-        const existsSpy = jest.spyOn(fs, "existsSync").mockImplementation(jest.fn());
-        const writeSpy = jest.spyOn(fs, "writeFileSync").mockImplementation(jest.fn());
         const logSpy = jest.spyOn(console, "log").mockImplementation(jest.fn());
         const errorSpy = jest.spyOn(console, "error").mockImplementation(jest.fn());
         cache.exportCombinedFiles("/bar", 2);
         expect(docsSpy).toHaveBeenCalledTimes(1);
         expect(readSpy).toHaveBeenCalledTimes(3);
         expect(existsSpy).not.toHaveBeenCalled();
-        expect(writeSpy).not.toHaveBeenCalled();
+        expect(writeFileSpy).not.toHaveBeenCalled();
         expect(logSpy).not.toHaveBeenCalled();
         expect(errorSpy).toHaveBeenCalledTimes(3);
         expect(errorSpy).toHaveBeenCalledWith("Fatal error: Unexpected data in /foo/one");
@@ -129,5 +131,70 @@ describe("SolrCache", () => {
         const readSpy = jest.spyOn(fs, "readFileSync").mockReturnValue('{"add":{"doc":{}}}');
         expect(cache.readSolrAddDocFromFile("foo")).toEqual({ add: { doc: {} } });
         expect(readSpy).toHaveBeenCalledWith("foo");
+    });
+
+    it("creates lock files when enabled", () => {
+        const cache = new SolrCache("/foo");
+        cache.lockPidIfEnabled("foo:123", "index");
+        expect(mkdirSpy).toHaveBeenCalledWith("/foo/foo/000/000/123", { recursive: true });
+        expect(writeFileSpy).toHaveBeenCalledWith("/foo/foo/000/000/123/123.index.lock", "");
+    });
+
+    it("removes lock files when enabled", () => {
+        const cache = new SolrCache("/foo");
+        existsSpy.mockReturnValue(true);
+        cache.unlockPidIfEnabled("foo:123", "index");
+        expect(existsSpy).toHaveBeenCalledWith("/foo/foo/000/000/123/123.index.lock");
+        expect(rmSpy).toHaveBeenCalledWith("/foo/foo/000/000/123/123.index.lock");
+    });
+
+    it("reports lock status based on file existence", () => {
+        const cache = new SolrCache("/foo");
+        existsSpy.mockReturnValueOnce(true).mockReturnValueOnce(false);
+        expect(cache.isPidLocked("foo:123", "index")).toBeTruthy();
+        expect(cache.isPidLocked("foo:123", "index")).toBeFalsy();
+        expect(existsSpy).toHaveBeenCalledTimes(2);
+        expect(existsSpy).toHaveBeenCalledWith("/foo/foo/000/000/123/123.index.lock");
+    });
+
+    it("returns false for non-cached documents", () => {
+        const cache = new SolrCache("/foo");
+        existsSpy.mockReturnValue(false);
+        expect(cache.getDocumentFromCache("foo:123")).toBeFalsy();
+        expect(existsSpy).toHaveBeenCalledWith("/foo/foo/000/000/123/123.json");
+    });
+
+    it("returns false for invalid cached documents", () => {
+        const cache = new SolrCache("/foo");
+        existsSpy.mockReturnValue(true);
+        const readSpy = jest.spyOn(cache, "readSolrAddDocFromFile").mockReturnValue({});
+        expect(cache.getDocumentFromCache("foo:123")).toBeFalsy();
+        expect(existsSpy).toHaveBeenCalledWith("/foo/foo/000/000/123/123.json");
+        expect(readSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("can fetch documents from the cache", () => {
+        const cache = new SolrCache("/foo");
+        existsSpy.mockReturnValue(true);
+        const readSpy = jest.spyOn(cache, "readSolrAddDocFromFile").mockReturnValue({
+            add: {
+                doc: {
+                    foo: "bar",
+                },
+            },
+        });
+        expect(cache.getDocumentFromCache("foo:123")).toEqual({ foo: "bar" });
+        expect(existsSpy).toHaveBeenCalledWith("/foo/foo/000/000/123/123.json");
+    });
+
+    it("disallows lock file generation when disabled", () => {
+        const cache = new SolrCache();
+        let errorMsg = "";
+        try {
+            cache.getLockFileForPid("foo:123", "index");
+        } catch (e) {
+            errorMsg = e.message;
+        }
+        expect(errorMsg).toEqual("getLockFileForPid not supported when cache disabled");
     });
 });

--- a/api/src/services/SolrCache.ts
+++ b/api/src/services/SolrCache.ts
@@ -31,9 +31,10 @@ export class SolrCache {
      * Returns the path to the PID file in the document cache if caching is enabled, false otherwise.
      *
      * @param pid PID being indexed
+     * @param extension File extension to use (default = json)
      * @returns false | string
      */
-    public getDocumentCachePath(pid: string, extension: string = "json"): false | string {
+    public getDocumentCachePath(pid: string, extension = "json"): false | string {
         if (!this.isEnabled()) {
             return false;
         }

--- a/api/src/services/SolrCache.ts
+++ b/api/src/services/SolrCache.ts
@@ -58,7 +58,7 @@ export class SolrCache {
 
     public lockPidIfEnabled(pid: string, action: string): void {
         if (this.isEnabled()) {
-            writeFileSync(this.getLockFileForPid(pid, action), "");
+            this.writeFile(this.getLockFileForPid(pid, action), "");
         }
     }
 

--- a/api/src/services/SolrCache.ts
+++ b/api/src/services/SolrCache.ts
@@ -23,14 +23,18 @@ export class SolrCache {
         return SolrCache.instance;
     }
 
+    public isEnabled(): boolean {
+        return this.cacheDir !== false;
+    }
+
     /**
      * Returns the path to the PID file in the document cache if caching is enabled, false otherwise.
      *
      * @param pid PID being indexed
      * @returns false | string
      */
-    public getDocumentCachePath(pid: string): false | string {
-        if (this.cacheDir === false) {
+    public getDocumentCachePath(pid: string, extension: string = "json"): false | string {
+        if (!this.isEnabled()) {
             return false;
         }
         // Create a file path that will prevent too many files from being stored in the
@@ -41,7 +45,34 @@ export class SolrCache {
         const chunk1 = paddedNumber.substring(len - 9, len - 6);
         const chunk2 = paddedNumber.substring(len - 6, len - 3);
         const chunk3 = paddedNumber.substring(len - 3, len);
-        return `${this.cacheDir}/${namespace}/${chunk1}/${chunk2}/${chunk3}/${number}.json`;
+        return `${this.cacheDir}/${namespace}/${chunk1}/${chunk2}/${chunk3}/${number}.${extension}`;
+    }
+
+    public getLockFileForPid(pid: string, action: string): string {
+        if (!this.isEnabled()) {
+            throw new Error("getLockFileForPid not supported when cache disabled");
+        }
+        return this.getDocumentCachePath(pid, action + ".lock") as string;
+    }
+
+    public lockPidIfEnabled(pid: string, action: string): void {
+        if (this.isEnabled()) {
+            writeFileSync(this.getLockFileForPid(pid, action), "");
+        }
+    }
+
+    public unlockPidIfEnabled(pid: string, action: string): void {
+        if (!this.isEnabled()) {
+            return;
+        }
+        const file = this.getLockFileForPid(pid, action);
+        if (existsSync(file)) {
+            rmSync(file);
+        }
+    }
+
+    public isPidLocked(pid: string, action: string) {
+        return existsSync(this.getLockFileForPid(pid, action));
     }
 
     public purgeFromCacheIfEnabled(pid: string): void {
@@ -78,7 +109,7 @@ export class SolrCache {
      * Returns an array of JSON files in the cache when cache is enabled, false otherwise.
      */
     public getDocumentsFromCache(): Array<string> | false {
-        if (this.cacheDir === false) {
+        if (!this.isEnabled()) {
             return false;
         }
         let pattern = this.cacheDir + "/**/**/**/*.json";

--- a/api/src/services/SolrCache.ts
+++ b/api/src/services/SolrCache.ts
@@ -92,6 +92,15 @@ export class SolrCache {
         return glob.sync(pattern, options);
     }
 
+    public getDocumentFromCache(pid: string): Record<string, unknown> | false {
+        const path = this.getDocumentCachePath(pid);
+        if (path && existsSync(path)) {
+            const doc = this.readSolrAddDocFromFile(path);
+            return doc?.add?.doc ?? false;
+        }
+        return false;
+    }
+
     public readSolrAddDocFromFile(file: string): SolrAddDoc {
         return JSON.parse(readFileSync(file).toString());
     }


### PR DESCRIPTION
TODO
- [x] Retrieve data from Solr cache instead of Fedora when possible
- [x] Invalidate cache when reindex jobs are queued
- [x] Use lock files in cache to avoid duplicate index jobs
- [x] Test coverage for everything