### PR TITLE
Refactor parent removal to EditorContext.

### DIFF
--- a/client/components/edit/parents/ParentList.test.tsx
+++ b/client/components/edit/parents/ParentList.test.tsx
@@ -77,10 +77,8 @@ describe("ParentList", () => {
                 },
             },
             action: {
-                clearPidFromChildListStorage: jest.fn(),
+                detachObjectFromParent: jest.fn(),
                 loadParentDetailsIntoStorage: jest.fn(),
-                removeFromObjectDetailsStorage: jest.fn(),
-                removeFromParentDetailsStorage: jest.fn(),
             },
         };
         fetchValues = {
@@ -127,18 +125,12 @@ describe("ParentList", () => {
 
     it("deletes parents on button click plus confirmation", async () => {
         const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(true);
-        fetchValues.action.fetchText.mockResolvedValue("ok");
+        editorValues.action.detachObjectFromParent.mockResolvedValue("ok");
         render(<ParentList pid={pid} />);
         await userEvent.setup().click(screen.getByText("Delete parent foo:122"));
         expect(confirmSpy).toHaveBeenCalledWith("Are you sure you wish to remove this parent?");
-        expect(fetchValues.action.fetchText).toHaveBeenCalledWith(
-            "http://localhost:9000/api/edit/object/foo%3A123/parent/foo%3A122",
-            { method: "DELETE" },
-        );
-        await waitFor(() => expect(editorValues.action.removeFromObjectDetailsStorage).toHaveBeenCalled());
-        expect(editorValues.action.removeFromObjectDetailsStorage).toHaveBeenCalledWith(pid);
-        expect(editorValues.action.removeFromParentDetailsStorage).toHaveBeenCalledWith(pid);
-        expect(editorValues.action.clearPidFromChildListStorage).toHaveBeenCalledWith("foo:122");
+        await waitFor(() => expect(globalValues.action.setSnackbarState).toHaveBeenCalled());
+        expect(editorValues.action.detachObjectFromParent).toHaveBeenCalledWith(pid, "foo:122");
         expect(globalValues.action.setSnackbarState).toHaveBeenCalledWith({
             message: "Successfully removed foo:123 from foo:122",
             open: true,
@@ -151,48 +143,19 @@ describe("ParentList", () => {
         render(<ParentList pid={pid} />);
         await userEvent.setup().click(screen.getByText("Delete parent foo:122"));
         expect(confirmSpy).toHaveBeenCalledWith("Are you sure you wish to remove this parent?");
-        expect(fetchValues.action.fetchText).not.toHaveBeenCalled();
+        expect(editorValues.action.detachObjectFromParent).not.toHaveBeenCalled();
     });
 
     it("handles bad return statuses", async () => {
         const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(true);
-        fetchValues.action.fetchText.mockResolvedValue("not ok");
+        editorValues.action.detachObjectFromParent.mockResolvedValue("not ok");
         render(<ParentList pid={pid} />);
         await userEvent.setup().click(screen.getByText("Delete parent foo:122"));
         expect(confirmSpy).toHaveBeenCalledWith("Are you sure you wish to remove this parent?");
-        expect(fetchValues.action.fetchText).toHaveBeenCalledWith(
-            "http://localhost:9000/api/edit/object/foo%3A123/parent/foo%3A122",
-            { method: "DELETE" },
-        );
         await waitFor(() => expect(globalValues.action.setSnackbarState).toHaveBeenCalled());
-        expect(editorValues.action.removeFromObjectDetailsStorage).not.toHaveBeenCalled();
-        expect(editorValues.action.removeFromParentDetailsStorage).not.toHaveBeenCalled();
-        expect(editorValues.action.clearPidFromChildListStorage).not.toHaveBeenCalled();
+        expect(editorValues.action.detachObjectFromParent).toHaveBeenCalledWith(pid, "foo:122");
         expect(globalValues.action.setSnackbarState).toHaveBeenCalledWith({
             message: "not ok",
-            open: true,
-            severity: "error",
-        });
-    });
-
-    it("handles exceptions on fetchText call", async () => {
-        const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(true);
-        fetchValues.action.fetchText.mockImplementation(() => {
-            throw new Error("boom");
-        });
-        render(<ParentList pid={pid} />);
-        await userEvent.setup().click(screen.getByText("Delete parent foo:122"));
-        expect(confirmSpy).toHaveBeenCalledWith("Are you sure you wish to remove this parent?");
-        expect(fetchValues.action.fetchText).toHaveBeenCalledWith(
-            "http://localhost:9000/api/edit/object/foo%3A123/parent/foo%3A122",
-            { method: "DELETE" },
-        );
-        await waitFor(() => expect(globalValues.action.setSnackbarState).toHaveBeenCalled());
-        expect(editorValues.action.removeFromObjectDetailsStorage).not.toHaveBeenCalled();
-        expect(editorValues.action.removeFromParentDetailsStorage).not.toHaveBeenCalled();
-        expect(editorValues.action.clearPidFromChildListStorage).not.toHaveBeenCalled();
-        expect(globalValues.action.setSnackbarState).toHaveBeenCalledWith({
-            message: "boom",
             open: true,
             severity: "error",
         });

--- a/client/components/edit/parents/ParentList.test.tsx
+++ b/client/components/edit/parents/ParentList.test.tsx
@@ -18,19 +18,11 @@ jest.mock("../../../context/EditorContext", () => ({
         return mockUseEditorContext();
     },
 }));
-const mockUseFetchContext = jest.fn();
-jest.mock("../../../context/FetchContext", () => ({
-    useFetchContext: () => {
-        return mockUseFetchContext();
-    },
-}));
-
 jest.mock("@mui/icons-material/Delete", () => (props) => props.titleAccess);
 
 describe("ParentList", () => {
     let globalValues;
     let editorValues;
-    let fetchValues;
     let pid: string;
     beforeEach(() => {
         pid = "foo:123";
@@ -81,14 +73,8 @@ describe("ParentList", () => {
                 loadParentDetailsIntoStorage: jest.fn(),
             },
         };
-        fetchValues = {
-            action: {
-                fetchText: jest.fn(),
-            },
-        };
         mockUseGlobalContext.mockReturnValue(globalValues);
         mockUseEditorContext.mockReturnValue(editorValues);
-        mockUseFetchContext.mockReturnValue(fetchValues);
     });
 
     afterEach(() => {

--- a/client/components/edit/parents/__snapshots__/ParentList.test.tsx.snap
+++ b/client/components/edit/parents/__snapshots__/ParentList.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ParentList renders a populated parent list correctly (full mode) 1`] = `
 <table
-  border="1"
+  border={1}
 >
   <tbody>
     <tr>
@@ -29,7 +29,7 @@ exports[`ParentList renders a populated parent list correctly (full mode) 1`] = 
 
 exports[`ParentList renders a populated parent list correctly (shallow mode) 1`] = `
 <table
-  border="1"
+  border={1}
 >
   <tbody>
     <tr>
@@ -60,7 +60,7 @@ exports[`ParentList renders a populated parent list correctly (shallow mode) 1`]
 
 exports[`ParentList renders an empty list correctly 1`] = `
 <table
-  border="1"
+  border={1}
 >
   <tbody>
     <tr>

--- a/client/context/EditorContext.test.tsx
+++ b/client/context/EditorContext.test.tsx
@@ -500,4 +500,66 @@ describe("useEditorContext", () => {
             expect(result.current.state.objectDetailsStorage).toEqual({});
         });
     });
+
+    describe("detachObjectFromParent", () => {
+        const pid = "foo:123";
+
+        it("detaches parents successfully", async () => {
+            fetchValues.action.fetchText.mockResolvedValue("ok");
+            const { result } = await renderHook(() => useEditorContext(), { wrapper: EditorContextProvider });
+
+            // Load data into storage so we can test that it gets cleared out after updates:
+            const fakeObjectDetails = { foo: "bar" };
+            fetchValues.action.fetchJSON.mockResolvedValue(fakeObjectDetails);
+            await act(async() => {
+                await result.current.action.loadObjectDetailsIntoStorage(pid);
+            });
+            expect(result.current.state.objectDetailsStorage[pid]).toEqual(fakeObjectDetails);
+            const fakeParentDetails = ["foo", "bar"];
+            fetchValues.action.fetchJSON.mockResolvedValue(fakeParentDetails);
+            await act(async() => {
+                await result.current.action.loadParentDetailsIntoStorage(pid);
+            });
+            expect(result.current.state.parentDetailsStorage[pid]["full"]).toEqual(fakeParentDetails);
+            const fakeChildPage = ["boop"];
+            fetchValues.action.fetchJSON.mockResolvedValue(fakeChildPage);
+            await act(async() => {
+                await result.current.action.loadChildrenIntoStorage("foo:122", 1, 1);
+            });
+            const expectedKey = result.current.action.getChildListStorageKey("foo:122", 1, 1);
+            expect(result.current.state.childListStorage[expectedKey]).toEqual(fakeChildPage);
+
+            // Now run the actual test:
+            let updateResult;
+            await act(async () => {
+                updateResult = await result.current.action.detachObjectFromParent(pid, "foo:122");
+            });
+            expect(fetchValues.action.fetchText).toHaveBeenCalledWith(
+                "http://localhost:9000/api/edit/object/foo%3A123/parent/foo%3A122",
+                { method: "DELETE" },
+            );
+            expect(updateResult).toEqual("ok");
+
+            // Various caches should now be empty due to clearing of changed data:
+            expect(result.current.state.objectDetailsStorage).toEqual({});
+            expect(result.current.state.parentDetailsStorage).toEqual({});
+            expect(result.current.state.childListStorage).toEqual({});
+        });
+
+        it("handles exceptions on fetchText call", async () => {
+            fetchValues.action.fetchText.mockImplementation(() => {
+                throw new Error("boom");
+            });
+            const { result } = await renderHook(() => useEditorContext(), { wrapper: EditorContextProvider });
+            let updateResult;
+            await act(async () => {
+                updateResult = await result.current.action.detachObjectFromParent(pid, "foo:122");
+            });
+            expect(fetchValues.action.fetchText).toHaveBeenCalledWith(
+                "http://localhost:9000/api/edit/object/foo%3A123/parent/foo%3A122",
+                { method: "DELETE" },
+            );
+            expect(updateResult).toEqual("boom");
+        });
+    });
 });

--- a/client/context/EditorContext.tsx
+++ b/client/context/EditorContext.tsx
@@ -1,5 +1,14 @@
 import React, { createContext, useContext, useReducer } from "react";
-import { editObjectCatalogUrl, getObjectChildCountsUrl, getObjectChildrenUrl, getObjectDetailsUrl, getObjectParentsUrl, getObjectRecursiveChildPidsUrl, getObjectStateUrl } from "../util/routes";
+import {
+    editObjectCatalogUrl,
+    getObjectChildCountsUrl,
+    getObjectChildrenUrl,
+    getObjectDetailsUrl,
+    getObjectParentsUrl,
+    getObjectRecursiveChildPidsUrl,
+    getObjectStateUrl,
+    getParentUrl,
+} from "../util/routes";
 import { useFetchContext } from "./FetchContext";
 import { extractFirstMetadataValue as utilExtractFirstMetadataValue } from "../util/metadata";
 import { TreeNode } from "../util/Breadcrumbs";
@@ -579,6 +588,31 @@ export const useEditorContext = () => {
             : [`Status failed to save; "${result}"`, "error"];
     }
 
+    /**
+     * Detach a child object from the specified parent.
+     * @param pid       Child PID
+     * @param parentPid Parent PID
+     * @returns A status string ("ok" on success, error message otherwise)
+     */
+    const detachObjectFromParent = async function (pid: string, parentPid: string): string {
+        const target = getParentUrl(pid, parentPid);
+        let result: string;
+        try {
+            result = await fetchText(target, { method: "DELETE" });
+        } catch (e) {
+            result = (e as Error).message ?? "Unexpected error";
+        }
+        if (result === "ok") {
+            // Clear and reload the cached object and its parents, since these have now changed!
+            removeFromObjectDetailsStorage(pid);
+            removeFromParentDetailsStorage(pid);
+            // Clear any cached lists belonging to the parent PID, because the
+            // order has potentially changed!
+            clearPidFromChildListStorage(parentPid);
+        }
+        return result;
+    };
+
     return {
         state: {
             currentAgents,
@@ -623,6 +657,7 @@ export const useEditorContext = () => {
             removeFromParentDetailsStorage,
             clearPidFromChildCountsStorage,
             clearPidFromChildListStorage,
+            detachObjectFromParent,
             updateObjectState,
         },
     };


### PR DESCRIPTION
This reduces the amount of low-level business logic that needs to be exposed to the higher-level component.

It also includes a minor fix to the table markup (border as number instead of string) to satisfy a type check.