### PR TITLE
Restore lost .hidden CSS class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- Restored .hidden CSS class accidentally removed in v2.6.
 
 ## 2.6 - 2026-02-02
 

--- a/client/styles/global.css
+++ b/client/styles/global.css
@@ -125,6 +125,10 @@
 
         --outline-color: var(--primary);
     }
+
+    .hidden {
+        display: none;
+    }
 }
 
 /* MUI: better default icon size */


### PR DESCRIPTION
The removal of the `.hidden` class in the previous release caused a "Loading..." message on the zooming paginator to remain forever.